### PR TITLE
refactor: loose BaseSocket + typed Socket/SocketTransport for plugins

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@socket-mesh/client",
 	"description": "A TCP socket pair for easily transmitting full messages without worrying about request size limits.",
-	"version": "18.1.6",
+	"version": "19.0.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/client/src/client-channels.ts
+++ b/packages/client/src/client-channels.ts
@@ -1,7 +1,8 @@
 import { ChannelDetails, ChannelMap, ChannelOptions, Channels, ChannelsOptions } from '@socket-mesh/channels';
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, toError } from '@socket-mesh/core';
+import { SocketTransport, toError } from '@socket-mesh/core';
 
 import { ClientTransport } from './client-transport.js';
+import { ServerPrivateMap } from './maps/server-map.js';
 
 export interface ClientChannelsOptions extends ChannelsOptions {
 	autoSubscribeOnConnect?: boolean
@@ -9,18 +10,14 @@ export interface ClientChannelsOptions extends ChannelsOptions {
 
 export class ClientChannels<
 	TChannel extends ChannelMap,
-	TIncoming extends MethodMap,
-	TService extends ServiceMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TState extends object
+	TState extends object = {}
 > extends Channels<TChannel> {
 	protected _preparingPendingSubscriptions: boolean;
 
-	protected readonly _transport: ClientTransport<TIncoming, TService, TOutgoing, TPrivateOutgoing, TState>;
+	protected readonly _transport: SocketTransport<{}, {}, TState, {}, {}, ServerPrivateMap>;
 	public autoSubscribeOnConnect: boolean;
 
-	constructor(transport: ClientTransport<TIncoming, TService, TOutgoing, TPrivateOutgoing, TState>, options?: ClientChannelsOptions) {
+	constructor(transport: ClientTransport<TState>, options?: ClientChannelsOptions) {
 		if (!options) {
 			options = {};
 		}
@@ -28,7 +25,7 @@ export class ClientChannels<
 		super(options);
 
 		this.autoSubscribeOnConnect = options.autoSubscribeOnConnect ?? true;
-		this._transport = transport;
+		this._transport = transport as unknown as SocketTransport<{}, {}, TState, {}, {}, ServerPrivateMap>;
 		this._preparingPendingSubscriptions = false;
 
 		this._transport.plugins.push({

--- a/packages/client/src/client-socket-options.ts
+++ b/packages/client/src/client-socket-options.ts
@@ -1,9 +1,7 @@
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, SocketOptions } from '@socket-mesh/core';
+import { BaseSocketOptions } from '@socket-mesh/core';
 import ws from 'isomorphic-ws';
 
 import { ClientAuthEngine, LocalStorageAuthEngineOptions } from './client-auth-engine.js';
-import { ClientPrivateMap } from './maps/client-map.js';
-import { ServerPrivateMap } from './maps/server-map.js';
 
 export interface AutoReconnectOptions {
 	initialDelay: number,
@@ -13,18 +11,8 @@ export interface AutoReconnectOptions {
 }
 
 export interface ClientSocketOptions<
-	TOutgoing extends PublicMethodMap = {},
-	TService extends ServiceMap = {},
-	TIncoming extends MethodMap = {},
-	TPrivateOutgoing extends PrivateMethodMap = {},
 	TState extends object = {}
-> extends SocketOptions<
-	TIncoming & ClientPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ServerPrivateMap,
-	TService,
-	TState
-	> {
+> extends BaseSocketOptions<TState> {
 	address: string | URL,
 
 	// A custom engine to use for storing and loading JWT auth tokens on the client side.
@@ -72,12 +60,8 @@ export function parseAutoReconnectOptions(value?: boolean | Partial<AutoReconnec
 }
 
 export function parseClientOptions<
-	TIncoming extends MethodMap,
-	TService extends ServiceMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
 	TState extends object
->(options: ClientSocketOptions<TOutgoing, TService, TIncoming, TPrivateOutgoing, TState> | string | URL): ClientSocketOptions<TOutgoing, TService, TIncoming, TPrivateOutgoing, TState> {
+>(options: ClientSocketOptions<TState> | string | URL): ClientSocketOptions<TState> {
 	if (typeof options === 'string' || 'pathname' in options) {
 		options = { address: options };
 	}

--- a/packages/client/src/client-socket.ts
+++ b/packages/client/src/client-socket.ts
@@ -5,7 +5,8 @@ import {
 	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, FunctionReturnType,
 	InvokeMethodOptions, InvokeServiceOptions, MessageEvent, MethodMap, PingEvent, PongEvent,
 	PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
-	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError, wait
+	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError, TypedRequestEvent,
+	TypedResponseEvent, TypedSocketEvent, wait
 } from '@socket-mesh/core';
 import { hydrateError } from '@socket-mesh/errors';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
@@ -132,8 +133,8 @@ export class ClientSocket<
 		return await super.deauthenticate();
 	}
 
-	override emit(event: 'request', data: RequestEvent<TIncoming & ClientPrivateMap, TService>): void;
-	override emit(event: 'response', data: ResponseEvent<TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>): void;
+	override emit(event: 'request', data: TypedRequestEvent<TIncoming & ClientPrivateMap, TService>): void;
+	override emit(event: 'response', data: TypedResponseEvent<TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>): void;
 	override emit(event: 'authStateChange', data: AuthStateChangeEvent): void;
 	override emit(event: 'authenticate', data: AuthenticateEvent): void;
 	override emit(event: 'badAuthToken', data: BadAuthTokenEvent): void;
@@ -174,7 +175,7 @@ export class ClientSocket<
 		this._clientTransport.isPingTimeoutDisabled = isDisabled;
 	}
 
-	override listen(): DemuxedConsumableStream<StreamEvent<SocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>>>;
+	override listen(): DemuxedConsumableStream<StreamEvent<TypedSocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>>>;
 	override listen(event: 'authStateChange'): DemuxedConsumableStream<AuthStateChangeEvent>;
 	override listen(event: 'authenticate'): DemuxedConsumableStream<AuthenticateEvent>;
 	override listen(event: 'badAuthToken'): DemuxedConsumableStream<BadAuthTokenEvent>;
@@ -190,10 +191,10 @@ export class ClientSocket<
 	override listen(event: 'ping'): DemuxedConsumableStream<PingEvent>;
 	override listen(event: 'pong'): DemuxedConsumableStream<PongEvent>;
 	override listen(event: 'removeAuthToken'): DemuxedConsumableStream<RemoveAuthTokenEvent>;
-	override listen(event: 'request'): DemuxedConsumableStream<RequestEvent<TIncoming & ClientPrivateMap, TService>>;
-	override listen(event: 'response'): DemuxedConsumableStream<ResponseEvent<TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>>;
-	override listen<U extends SocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
-	override listen<U extends SocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
+	override listen(event: 'request'): DemuxedConsumableStream<TypedRequestEvent<TIncoming & ClientPrivateMap, TService>>;
+	override listen(event: 'response'): DemuxedConsumableStream<TypedResponseEvent<TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>>;
+	override listen<U extends TypedSocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
+	override listen<U extends TypedSocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
 		return super.listen<U, V>(event ?? '');
 	}
 

--- a/packages/client/src/client-socket.ts
+++ b/packages/client/src/client-socket.ts
@@ -1,12 +1,12 @@
 import { SignedAuthToken } from '@socket-mesh/auth';
 import { ChannelMap } from '@socket-mesh/channels';
 import {
-	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent,
-	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, FunctionReturnType,
-	InvokeMethodOptions, InvokeServiceOptions, MessageEvent, MethodMap, PingEvent, PongEvent,
-	PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
-	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError, TypedRequestEvent,
-	TypedResponseEvent, TypedSocketEvent, wait
+	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, BaseSocket, CloseEvent,
+	ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent,
+	FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MessageEvent, MethodMap,
+	PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent,
+	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, SocketEvent, toError,
+	TypedRequestEvent, TypedResponseEvent, TypedSocketEvent, wait
 } from '@socket-mesh/core';
 import { hydrateError } from '@socket-mesh/errors';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
@@ -28,19 +28,13 @@ export class ClientSocket<
 	TState extends object = {},
 	TIncoming extends MethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {}
-> extends Socket<
-	TIncoming & ClientPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ServerPrivateMap,
-	TService,
-	TState
-	> {
-	private readonly _clientTransport: ClientTransport<TIncoming, TService, TOutgoing, TPrivateOutgoing, TState>;
-	public readonly channels: ClientChannels<TChannel, TIncoming, TService, TOutgoing, TPrivateOutgoing, TState>;
+> extends BaseSocket<TState> {
+	private readonly _clientTransport: ClientTransport<TState>;
+	public readonly channels: ClientChannels<TChannel, TState>;
 
 	constructor(address: string | URL);
-	constructor(options: ClientSocketOptions<TOutgoing, TService, TIncoming, TPrivateOutgoing, TState>);
-	constructor(options: ClientSocketOptions<TOutgoing, TService, TIncoming, TPrivateOutgoing, TState> | string | URL) {
+	constructor(options: ClientSocketOptions<TState>);
+	constructor(options: ClientSocketOptions<TState> | string | URL) {
 		options = parseClientOptions(options);
 
 		options.handlers =
@@ -59,7 +53,7 @@ export class ClientSocket<
 		super(clientTransport, options);
 
 		this._clientTransport = clientTransport;
-		this.channels = new ClientChannels<TChannel, TIncoming, TService, TOutgoing, TPrivateOutgoing, TState>(this._clientTransport, options);
+		this.channels = new ClientChannels<TChannel, TState>(this._clientTransport, options);
 
 		if (options.autoConnect !== false) {
 			this.connect(options);

--- a/packages/client/src/client-socket.ts
+++ b/packages/client/src/client-socket.ts
@@ -1,6 +1,6 @@
 import { SignedAuthToken } from '@socket-mesh/auth';
 import { ChannelMap } from '@socket-mesh/channels';
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, Socket, toError, wait } from '@socket-mesh/core';
+import { FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName, Socket, toError, wait } from '@socket-mesh/core';
 import { hydrateError } from '@socket-mesh/errors';
 
 import { ClientChannels } from './client-channels.js';
@@ -125,6 +125,17 @@ export class ClientSocket<
 		return await super.deauthenticate();
 	}
 
+	override invoke<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
+	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
+	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
+	override invoke<TMethod extends keyof TOutgoing & string>(options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
+	override invoke(
+		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
+		arg?: unknown
+	): Promise<unknown> {
+		return super.invoke(methodOptions, arg);
+	}
+
 	public get isPingTimeoutDisabled(): boolean {
 		return this._clientTransport.isPingTimeoutDisabled;
 	}
@@ -144,6 +155,15 @@ export class ClientSocket<
 	public reconnect(code?: number, reason?: string) {
 		this.disconnect(code, reason);
 		this.connect();
+	}
+
+	override transmit<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<void>;
+	override transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<void>;
+	override transmit(
+		serviceAndMethod: [string, string] | string,
+		arg?: unknown
+	): Promise<void> {
+		return super.transmit(serviceAndMethod, arg);
 	}
 
 	get type(): 'client' {

--- a/packages/client/src/client-socket.ts
+++ b/packages/client/src/client-socket.ts
@@ -3,9 +3,9 @@ import { ChannelMap } from '@socket-mesh/channels';
 import {
 	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, BaseSocket, CloseEvent,
 	ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent,
-	FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MessageEvent, MethodMap,
+	FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MessageEvent,
 	PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent,
-	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, SocketEvent, toError,
+	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError,
 	TypedRequestEvent, TypedResponseEvent, TypedSocketEvent, wait
 } from '@socket-mesh/core';
 import { hydrateError } from '@socket-mesh/errors';
@@ -26,9 +26,16 @@ export class ClientSocket<
 	TChannel extends ChannelMap = ChannelMap,
 	TService extends ServiceMap = {},
 	TState extends object = {},
-	TIncoming extends MethodMap = {},
+	TIncoming extends PublicMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {}
-> extends BaseSocket<TState> {
+> extends BaseSocket<TState> implements Socket<
+	TIncoming & ClientPrivateMap,
+	TOutgoing,
+	TState,
+	TService,
+	{},
+	TPrivateOutgoing & ServerPrivateMap
+> {
 	private readonly _clientTransport: ClientTransport<TState>;
 	public readonly channels: ClientChannels<TChannel, TState>;
 

--- a/packages/client/src/client-socket.ts
+++ b/packages/client/src/client-socket.ts
@@ -22,11 +22,11 @@ import { ClientPrivateMap } from './maps/client-map.js';
 import { ServerPrivateMap } from './maps/server-map.js';
 
 export class ClientSocket<
+	TIncoming extends PublicMethodMap = {},
 	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = ChannelMap,
 	TService extends ServiceMap = {},
 	TState extends object = {},
-	TIncoming extends PublicMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {}
 > extends BaseSocket<TState> implements Socket<
 	TIncoming & ClientPrivateMap,

--- a/packages/client/src/client-socket.ts
+++ b/packages/client/src/client-socket.ts
@@ -1,7 +1,14 @@
 import { SignedAuthToken } from '@socket-mesh/auth';
 import { ChannelMap } from '@socket-mesh/channels';
-import { FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName, Socket, toError, wait } from '@socket-mesh/core';
+import {
+	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent,
+	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, FunctionReturnType,
+	InvokeMethodOptions, InvokeServiceOptions, MessageEvent, MethodMap, PingEvent, PongEvent,
+	PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
+	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError, wait
+} from '@socket-mesh/core';
 import { hydrateError } from '@socket-mesh/errors';
+import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
 
 import { ClientChannels } from './client-channels.js';
 import { AutoReconnectOptions, ClientSocketOptions, ConnectOptions, parseClientOptions } from './client-socket-options.js';
@@ -125,6 +132,29 @@ export class ClientSocket<
 		return await super.deauthenticate();
 	}
 
+	override emit(event: 'request', data: RequestEvent<TIncoming & ClientPrivateMap, TService>): void;
+	override emit(event: 'response', data: ResponseEvent<TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>): void;
+	override emit(event: 'authStateChange', data: AuthStateChangeEvent): void;
+	override emit(event: 'authenticate', data: AuthenticateEvent): void;
+	override emit(event: 'badAuthToken', data: BadAuthTokenEvent): void;
+	override emit(event: 'close', data: CloseEvent): void;
+	override emit(event: 'connect', data: ConnectEvent): void;
+	override emit(event: 'connectAbort', data: DisconnectEvent): void;
+	override emit(event: 'connecting', data: ConnectingEvent): void;
+	override emit(event: 'deauthenticate', data: DeauthenticateEvent): void;
+	override emit(event: 'disconnect', data: DisconnectEvent): void;
+	override emit(event: 'end'): void;
+	override emit(event: 'error', data: ErrorEvent): void;
+	override emit(event: 'message', data: MessageEvent): void;
+	override emit(event: 'ping', data: PingEvent): void;
+	override emit(event: 'pong', data: PongEvent): void;
+	override emit(event: 'removeAuthToken', data: RemoveAuthTokenEvent): void;
+	override emit(event: 'request', data: RequestEvent): void;
+	override emit(event: 'response', data: ResponseEvent): void;
+	override emit(event: string, data?: SocketEvent): void {
+		(super.emit as (event: string, data?: SocketEvent) => void)(event, data);
+	}
+
 	override invoke<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
 	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
 	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
@@ -142,6 +172,29 @@ export class ClientSocket<
 
 	public set isPingTimeoutDisabled(isDisabled: boolean) {
 		this._clientTransport.isPingTimeoutDisabled = isDisabled;
+	}
+
+	override listen(): DemuxedConsumableStream<StreamEvent<SocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>>>;
+	override listen(event: 'authStateChange'): DemuxedConsumableStream<AuthStateChangeEvent>;
+	override listen(event: 'authenticate'): DemuxedConsumableStream<AuthenticateEvent>;
+	override listen(event: 'badAuthToken'): DemuxedConsumableStream<BadAuthTokenEvent>;
+	override listen(event: 'close'): DemuxedConsumableStream<CloseEvent>;
+	override listen(event: 'connect'): DemuxedConsumableStream<ConnectEvent>;
+	override listen(event: 'connectAbort'): DemuxedConsumableStream<DisconnectEvent>;
+	override listen(event: 'connecting'): DemuxedConsumableStream<ConnectingEvent>;
+	override listen(event: 'deauthenticate'): DemuxedConsumableStream<DeauthenticateEvent>;
+	override listen(event: 'disconnect'): DemuxedConsumableStream<DisconnectEvent>;
+	override listen(event: 'end'): DemuxedConsumableStream<void>;
+	override listen(event: 'error'): DemuxedConsumableStream<ErrorEvent>;
+	override listen(event: 'message'): DemuxedConsumableStream<MessageEvent>;
+	override listen(event: 'ping'): DemuxedConsumableStream<PingEvent>;
+	override listen(event: 'pong'): DemuxedConsumableStream<PongEvent>;
+	override listen(event: 'removeAuthToken'): DemuxedConsumableStream<RemoveAuthTokenEvent>;
+	override listen(event: 'request'): DemuxedConsumableStream<RequestEvent<TIncoming & ClientPrivateMap, TService>>;
+	override listen(event: 'response'): DemuxedConsumableStream<ResponseEvent<TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>>;
+	override listen<U extends SocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
+	override listen<U extends SocketEvent<TIncoming & ClientPrivateMap, TOutgoing, TPrivateOutgoing & ServerPrivateMap, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
+		return super.listen<U, V>(event ?? '');
 	}
 
 	public get pingTimeoutMs(): number {

--- a/packages/client/src/client-transport.ts
+++ b/packages/client/src/client-transport.ts
@@ -1,5 +1,5 @@
 import { AuthToken } from '@socket-mesh/auth';
-import { BaseSocketTransport, InvokeMethodOptions, InvokeServiceOptions, SocketStatus, toError } from '@socket-mesh/core';
+import { BaseSocketTransport, InvokeMethodOptions, InvokeServiceOptions, SocketStatus, SocketTransport, toError } from '@socket-mesh/core';
 import { HandshakeError, hydrateError, SocketClosedError, SocketProtocolErrorStatuses } from '@socket-mesh/errors';
 import ws from 'isomorphic-ws';
 
@@ -9,7 +9,7 @@ import { HandshakeStatus } from './maps/server-map.js';
 
 export class ClientTransport<
 	TState extends object = {}
-> extends BaseSocketTransport<TState> {
+> extends BaseSocketTransport<TState> implements SocketTransport<{}, {}, TState> {
 	private _autoReconnect: AutoReconnectOptions | false;
 
 	private _connectAttempts: number;

--- a/packages/client/src/client-transport.ts
+++ b/packages/client/src/client-transport.ts
@@ -1,5 +1,5 @@
 import { AuthToken } from '@socket-mesh/auth';
-import { FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName, SocketStatus, SocketTransport, toError } from '@socket-mesh/core';
+import { InvokeMethodOptions, InvokeServiceOptions, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, SocketStatus, SocketTransport, toError } from '@socket-mesh/core';
 import { HandshakeError, hydrateError, SocketClosedError, SocketProtocolErrorStatuses } from '@socket-mesh/errors';
 import ws from 'isomorphic-ws';
 
@@ -141,16 +141,10 @@ export class ClientTransport<
 		return status;
 	}
 
-	override invoke<TMethod extends keyof TOutgoing>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void];
-	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void];
-	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void];
-	override invoke<TMethod extends keyof TOutgoing>(options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void];
-	override invoke<TMethod extends keyof (TPrivateOutgoing & ServerPrivateMap)>(method: TMethod, arg: Parameters<(TPrivateOutgoing & ServerPrivateMap)[TMethod]>[0]): [Promise<FunctionReturnType<(TPrivateOutgoing & ServerPrivateMap)[TMethod]>>, () => void];
-	override invoke<TMethod extends keyof (TPrivateOutgoing & ServerPrivateMap)>(options: InvokeMethodOptions<(TPrivateOutgoing & ServerPrivateMap), TMethod>, arg?: Parameters<(TPrivateOutgoing & ServerPrivateMap)[TMethod]>[0]): [Promise<FunctionReturnType<(TPrivateOutgoing & ServerPrivateMap)[TMethod]>>, () => void];
-	override invoke<TServiceName extends ServiceName<TService>, TServiceMethod extends ServiceMethodName<TService, TServiceName>, TMethod extends keyof TOutgoing, TPrivateMethod extends keyof (TPrivateOutgoing & ServerPrivateMap)>(
-		methodOptions: [TServiceName, TServiceMethod, (false | number)?] | InvokeMethodOptions<(TPrivateOutgoing & ServerPrivateMap), TPrivateMethod> | InvokeMethodOptions<TOutgoing, TMethod> | InvokeServiceOptions<TService, TServiceName, TServiceMethod> | TMethod | TPrivateMethod,
-		arg?: (Parameters<(TPrivateOutgoing & ServerPrivateMap)[TPrivateMethod]> | Parameters<TOutgoing[TMethod]> | Parameters<TService[TServiceName][TServiceMethod]>)[0]
-	): [Promise<FunctionReturnType<(TPrivateOutgoing & ServerPrivateMap)[TPrivateMethod] | TOutgoing[TMethod] | TService[TServiceName][TServiceMethod]>>, () => void] {
+	override invoke(
+		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
+		arg?: unknown
+	): [Promise<unknown>, () => void] {
 		let wasAborted = false;
 		let abort: () => void =
 			() => { wasAborted = true; };
@@ -163,7 +157,7 @@ export class ClientTransport<
 				}
 			})
 			.then(() => {
-				const result = super.invoke(methodOptions as TMethod, arg);
+				const result = super.invoke(methodOptions, arg);
 				abort = result[1];
 
 				if (wasAborted) {
@@ -308,17 +302,17 @@ export class ClientTransport<
 		return super.status;
 	}
 
-	override transmit<TMethod extends keyof TOutgoing>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<void>;
-	override transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<void>;
-	override transmit<TMethod extends keyof (TPrivateOutgoing & ServerPrivateMap)>(method: TMethod, arg?: Parameters<(TPrivateOutgoing & ServerPrivateMap)[TMethod]>[0]): Promise<void>;
-	override async transmit<TServiceName extends ServiceName<TService>, TServiceMethod extends ServiceMethodName<TService, TServiceName>, TMethod extends keyof TOutgoing>(serviceAndMethod: [TServiceName, TServiceMethod] | TMethod, arg?: (Parameters<TOutgoing[TMethod]> | Parameters<TService[TServiceName][TServiceMethod]>)[0]): Promise<void> {
+	override async transmit(
+		serviceAndMethod: [string, string] | string,
+		arg?: unknown
+	): Promise<void> {
 		if (this.status === 'closed') {
 			this.connect();
 
 			await this.socket.listen('connect').once();
 		}
 
-		await super.transmit(serviceAndMethod as TMethod, arg);
+		await super.transmit(serviceAndMethod, arg);
 	}
 
 	private tryReconnect(initialDelay?: number): void {

--- a/packages/client/src/client-transport.ts
+++ b/packages/client/src/client-transport.ts
@@ -1,26 +1,15 @@
 import { AuthToken } from '@socket-mesh/auth';
-import { InvokeMethodOptions, InvokeServiceOptions, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, SocketStatus, SocketTransport, toError } from '@socket-mesh/core';
+import { BaseSocketTransport, InvokeMethodOptions, InvokeServiceOptions, SocketStatus, toError } from '@socket-mesh/core';
 import { HandshakeError, hydrateError, SocketClosedError, SocketProtocolErrorStatuses } from '@socket-mesh/errors';
 import ws from 'isomorphic-ws';
 
 import { ClientAuthEngine, isAuthEngine, LocalStorageAuthEngine } from './client-auth-engine.js';
 import { AutoReconnectOptions, ClientSocketOptions, ConnectOptions, parseAutoReconnectOptions } from './client-socket-options.js';
-import { ClientPrivateMap } from './maps/client-map.js';
-import { HandshakeStatus, ServerPrivateMap } from './maps/server-map.js';
+import { HandshakeStatus } from './maps/server-map.js';
 
 export class ClientTransport<
-	TIncoming extends MethodMap,
-	TService extends ServiceMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TState extends object
-> extends SocketTransport<
-	TIncoming & ClientPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ServerPrivateMap,
-	TService,
-	TState
-	> {
+	TState extends object = {}
+> extends BaseSocketTransport<TState> {
 	private _autoReconnect: AutoReconnectOptions | false;
 
 	private _connectAttempts: number;
@@ -37,7 +26,7 @@ export class ClientTransport<
 
 	public type: 'client';
 
-	constructor(options: ClientSocketOptions<TOutgoing, TService, TIncoming, TPrivateOutgoing, TState>) {
+	constructor(options: ClientSocketOptions<TState>) {
 		super(options);
 
 		this.type = 'client';

--- a/packages/client/src/handlers/kickout.ts
+++ b/packages/client/src/handlers/kickout.ts
@@ -9,7 +9,7 @@ export async function kickOutHandler(
 	{ options, socket }: RequestHandlerArgs<
 		KickOutOptions,
 		{},
-		ClientSocket<{}, ChannelMap>,
+		ClientSocket<{}, {}, ChannelMap>,
 		ClientTransport<{}>
 	>
 ): Promise<void> {

--- a/packages/client/src/handlers/kickout.ts
+++ b/packages/client/src/handlers/kickout.ts
@@ -3,19 +3,14 @@ import { RequestHandlerArgs } from '@socket-mesh/core';
 
 import { ClientSocket } from '../client-socket.js';
 import { ClientTransport } from '../client-transport.js';
-import { ClientPrivateMap, KickOutOptions } from '../maps/client-map.js';
-import { ServerPrivateMap } from '../maps/server-map.js';
+import { KickOutOptions } from '../maps/client-map.js';
 
 export async function kickOutHandler(
 	{ options, socket }: RequestHandlerArgs<
 		KickOutOptions,
-		ClientPrivateMap,
-		{},
-		ServerPrivateMap,
-		{},
 		{},
 		ClientSocket<{}, ChannelMap>,
-		ClientTransport<{}, {}, {}, {}, { }>
+		ClientTransport<{}>
 	>
 ): Promise<void> {
 	socket.channels.kickOut(options.channel, options.message);

--- a/packages/client/src/handlers/publish.ts
+++ b/packages/client/src/handlers/publish.ts
@@ -3,19 +3,13 @@ import { RequestHandlerArgs } from '@socket-mesh/core';
 
 import { ClientSocket } from '../client-socket.js';
 import { ClientTransport } from '../client-transport.js';
-import { ClientPrivateMap } from '../maps/client-map.js';
-import { ServerPrivateMap } from '../maps/server-map.js';
 
 export async function publishHandler(
 	{ options, socket }: RequestHandlerArgs<
 		PublishOptions,
-		ClientPrivateMap,
-		{},
-		ServerPrivateMap,
-		{},
 		{},
 		ClientSocket<{}, ChannelMap>,
-		ClientTransport<{}, {}, {}, {}, { }>
+		ClientTransport<{}>
 	>
 ): Promise<void> {
 	socket.channels.write(options.channel, options.data);

--- a/packages/client/src/handlers/publish.ts
+++ b/packages/client/src/handlers/publish.ts
@@ -8,7 +8,7 @@ export async function publishHandler(
 	{ options, socket }: RequestHandlerArgs<
 		PublishOptions,
 		{},
-		ClientSocket<{}, ChannelMap>,
+		ClientSocket<{}, {}, ChannelMap>,
 		ClientTransport<{}>
 	>
 ): Promise<void> {

--- a/packages/client/src/plugins/batching-plugin.ts
+++ b/packages/client/src/plugins/batching-plugin.ts
@@ -161,8 +161,8 @@ export class ResponseBatchingPlugin<
 	TService extends ServiceMap,
 	TState extends object
 > extends BatchingPlugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState, 'responseBatching'> {
-	private _continue: ((requests: AnyResponse<TOutgoing, TPrivateOutgoing, TService>[], cb?: (error?: Error) => void) => void) | null;
-	private _responses: AnyResponse<TOutgoing, TPrivateOutgoing, TService>[];
+	private _continue: ((requests: AnyResponse[], cb?: (error?: Error) => void) => void) | null;
+	private _responses: AnyResponse[];
 
 	constructor(options?: Omit<BatchingPluginOptions, 'type'>) {
 		super({

--- a/packages/client/src/plugins/batching-plugin.ts
+++ b/packages/client/src/plugins/batching-plugin.ts
@@ -112,8 +112,8 @@ export class RequestBatchingPlugin<
 	TService extends ServiceMap,
 	TState extends object
 > extends BatchingPlugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState, 'requestBatching'> {
-	private _continue: ((requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[], cb?: (error?: Error) => void) => void) | null;
-	private _requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[];
+	private _continue: ((requests: AnyRequest[], cb?: (error?: Error) => void) => void) | null;
+	private _requests: AnyRequest[];
 
 	constructor(options?: Omit<BatchingPluginOptions, 'type'>) {
 		super({

--- a/packages/client/src/plugins/batching-plugin.ts
+++ b/packages/client/src/plugins/batching-plugin.ts
@@ -1,4 +1,3 @@
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from '@socket-mesh/core';
 import { AnyRequest, AnyResponse, Plugin, SendRequestPluginArgs, SendResponsePluginArgs } from '@socket-mesh/core';
 
 export interface BatchingPluginOptions<TType = string> {
@@ -14,13 +13,8 @@ export interface BatchingPluginOptions<TType = string> {
 }
 
 export abstract class BatchingPlugin<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object,
 	TType extends string
-> implements Plugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+> implements Plugin {
 	private _batchingIntervalId: NodeJS.Timeout | null;
 	private _handshakeTimeoutId: NodeJS.Timeout | null;
 
@@ -105,13 +99,7 @@ export abstract class BatchingPlugin<
 	}
 }
 
-export class RequestBatchingPlugin<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends BatchingPlugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState, 'requestBatching'> {
+export class RequestBatchingPlugin extends BatchingPlugin<'requestBatching'> {
 	private _continue: ((requests: AnyRequest[], cb?: (error?: Error) => void) => void) | null;
 	private _requests: AnyRequest[];
 
@@ -143,7 +131,7 @@ export class RequestBatchingPlugin<
 		}
 	}
 
-	public sendRequest({ cont, requests }: SendRequestPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void {
+	public sendRequest({ cont, requests }: SendRequestPluginArgs): void {
 		if (!this.isBatching) {
 			cont(requests);
 			return;
@@ -154,13 +142,7 @@ export class RequestBatchingPlugin<
 	}
 }
 
-export class ResponseBatchingPlugin<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends BatchingPlugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState, 'responseBatching'> {
+export class ResponseBatchingPlugin extends BatchingPlugin<'responseBatching'> {
 	private _continue: ((requests: AnyResponse[], cb?: (error?: Error) => void) => void) | null;
 	private _responses: AnyResponse[];
 
@@ -185,7 +167,7 @@ export class ResponseBatchingPlugin<
 		}
 	}
 
-	public sendResponse({ cont, responses }: SendResponsePluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void {
+	public sendResponse({ cont, responses }: SendResponsePluginArgs): void {
 		if (!this.isBatching) {
 			cont(responses);
 			return;

--- a/packages/client/src/plugins/in-order-plugin.ts
+++ b/packages/client/src/plugins/in-order-plugin.ts
@@ -1,32 +1,20 @@
-import { MessageRawPluginArgs, MethodMap, Plugin, PluginArgs, PrivateMethodMap, PublicMethodMap, ServiceMap } from '@socket-mesh/core';
+import { MessageRawPluginArgs, Plugin, PluginArgs } from '@socket-mesh/core';
 import { WritableConsumableStream } from '@socket-mesh/writable-consumable-stream';
 import ws from 'isomorphic-ws';
 import { RawData } from 'ws';
 
-interface InboundMessage<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends MessageRawPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+interface InboundMessage extends MessageRawPluginArgs {
 	callback: (err: Error | null, data: string | ws.RawData) => void
 }
 
-export class InOrderPlugin<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> implements Plugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
-	private readonly _inboundMessageStream: WritableConsumableStream<InboundMessage<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>>;
+export class InOrderPlugin implements Plugin {
+	private readonly _inboundMessageStream: WritableConsumableStream<InboundMessage>;
 
 	type: 'inOrder';
 	// private readonly _outboundMessageStream: WritableConsumableStream<SendRequestPluginArgs<T>>;
 
 	constructor() {
-		this._inboundMessageStream = new WritableConsumableStream<InboundMessage<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>>();
+		this._inboundMessageStream = new WritableConsumableStream<InboundMessage>();
 		// this._outboundMessageStream = new WritableConsumableStream<SendRequestPluginArgs<T>>;
 		this.type = 'inOrder';
 		this.handleInboundMessageStream();
@@ -70,7 +58,7 @@ export class InOrderPlugin<
 	}
 */
 
-	onEnd({ transport }: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void {
+	onEnd({ transport }: PluginArgs): void {
 		if (transport.streamCleanupMode === 'close') {
 			this._inboundMessageStream.close();
 			// this._outboundMessageStream.close();
@@ -80,7 +68,7 @@ export class InOrderPlugin<
 		}
 	}
 
-	onMessageRaw(options: MessageRawPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): Promise<RawData | string> {
+	onMessageRaw(options: MessageRawPluginArgs): Promise<RawData | string> {
 		let callback: (err: Error | null, data: string | ws.RawData) => void;
 
 		const promise = new Promise<RawData | string>((resolve, reject) => {

--- a/packages/client/src/plugins/offline-plugin.ts
+++ b/packages/client/src/plugins/offline-plugin.ts
@@ -1,14 +1,8 @@
-import { AnyRequest, MethodMap, Plugin, PrivateMethodMap, PublicMethodMap, SendRequestPluginArgs, ServiceMap } from '@socket-mesh/core';
+import { AnyRequest, Plugin, SendRequestPluginArgs } from '@socket-mesh/core';
 
 const SYSTEM_METHODS = ['#handshake', '#removeAuthToken'];
 
-export class OfflinePlugin<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> implements Plugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+export class OfflinePlugin implements Plugin {
 	private _continue: ((requests: AnyRequest[], cb?: (error?: Error) => void) => void) | null;
 	private _isReady: boolean;
 	private _requests: AnyRequest[][];
@@ -50,7 +44,7 @@ export class OfflinePlugin<
 		this.flush();
 	}
 
-	public sendRequest({ cont, requests }: SendRequestPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void {
+	public sendRequest({ cont, requests }: SendRequestPluginArgs): void {
 		if (this._isReady) {
 			cont(requests);
 			return;

--- a/packages/client/src/plugins/offline-plugin.ts
+++ b/packages/client/src/plugins/offline-plugin.ts
@@ -9,9 +9,9 @@ export class OfflinePlugin<
 	TService extends ServiceMap,
 	TState extends object
 > implements Plugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
-	private _continue: ((requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[], cb?: (error?: Error) => void) => void) | null;
+	private _continue: ((requests: AnyRequest[], cb?: (error?: Error) => void) => void) | null;
 	private _isReady: boolean;
-	private _requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[][];
+	private _requests: AnyRequest[][];
 
 	type: 'offline';
 
@@ -56,11 +56,11 @@ export class OfflinePlugin<
 			return;
 		}
 
-		const systemRequests = requests.filter(item => SYSTEM_METHODS.indexOf(String(item.method)) > -1);
-		let otherRequests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[] = requests;
+		const systemRequests = requests.filter(item => SYSTEM_METHODS.indexOf(item.method) > -1);
+		let otherRequests: AnyRequest[] = requests;
 
 		if (systemRequests.length) {
-			otherRequests = (systemRequests.length === requests.length) ? [] : requests.filter(item => SYSTEM_METHODS.indexOf(String(item.method)) < 0);
+			otherRequests = (systemRequests.length === requests.length) ? [] : requests.filter(item => SYSTEM_METHODS.indexOf(item.method) < 0);
 		}
 
 		if (otherRequests.length) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@socket-mesh/core",
-	"version": "1.0.4",
+	"version": "2.0.0",
 	"description": "Core module for SocketMesh Server",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/src/maps/handler-map.ts
+++ b/packages/core/src/maps/handler-map.ts
@@ -1,23 +1,22 @@
 import { RequestHandler } from '../request-handler.js';
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './method-map.js';
+import { BaseSocketTransport } from '../socket-transport.js';
+import { BaseSocket } from '../socket.js';
+import { MethodMap } from './method-map.js';
 
 export type HandlerMap<
 	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
+	TState extends object,
+	TSocket extends BaseSocket<TState> = BaseSocket<TState>,
+	TTransport extends BaseSocketTransport<TState> = BaseSocketTransport<TState>
 > = Partial<
 	{
 		[K in keyof TIncoming]:
 		RequestHandler<
 			Parameters<TIncoming[K]>[0],
 			ReturnType<TIncoming[K]>,
-			TIncoming,
-			TOutgoing,
-			TPrivateOutgoing,
-			TService,
-			TState
+			TState,
+			TSocket,
+			TTransport
 		>
 	}
 >;

--- a/packages/core/src/packet.ts
+++ b/packages/core/src/packet.ts
@@ -1,33 +1,34 @@
 import { MethodMap, ServiceMap } from './maps/method-map.js';
 
-export type AnyPacket<
-	TIncoming extends MethodMap,
-	TService extends ServiceMap
-> = MethodPacket<TIncoming> | ServicePacket<TService>;
+export type AnyPacket = MethodPacket | ServicePacket;
 
-export type MethodPacket<TMethodMap extends MethodMap> =
+export type IncomingMethodPacket<TMethodMap extends MethodMap> =
 	{ [TMethod in keyof TMethodMap]:
-		MethodRequestPacket<TMethodMap, TMethod>
+		IncomingMethodRequestPacket<TMethodMap, TMethod>
 	}[keyof TMethodMap];
 
-export interface MethodRequestPacket<TMethodMap extends MethodMap, TMethod extends keyof TMethodMap> extends RequestPacket {
+export interface IncomingMethodRequestPacket<
+	TMethodMap extends MethodMap,
+	TMethod extends keyof TMethodMap
+> extends RequestPacket {
 	ackTimeoutMs?: boolean | number,
 	data: Parameters<TMethodMap[TMethod]>[0],
 	method: TMethod
 }
 
-interface RequestPacket {
-	cid?: number
-}
+export type IncomingPacket<
+	TIncoming extends MethodMap,
+	TService extends ServiceMap
+> = IncomingMethodPacket<TIncoming> | IncomingServicePacket<TService>;
 
-export type ServicePacket<TServiceMap extends ServiceMap> =
+export type IncomingServicePacket<TServiceMap extends ServiceMap> =
 	{ [TService in keyof TServiceMap]:
 		{ [TMethod in keyof TServiceMap[TService]]:
-			ServiceRequestPacket<TServiceMap, TService, TMethod>
+			IncomingServiceRequestPacket<TServiceMap, TService, TMethod>
 		}[keyof TServiceMap[TService]]
 	}[keyof TServiceMap];
 
-export interface ServiceRequestPacket<
+export interface IncomingServiceRequestPacket<
 	TServiceMap extends ServiceMap,
 	TService extends keyof TServiceMap,
 	TMethod extends keyof TServiceMap[TService]
@@ -38,10 +39,32 @@ export interface ServiceRequestPacket<
 	service: TService
 }
 
-export function isRequestPacket<
-	TIncoming extends MethodMap,
-	TService extends ServiceMap
->(packet: unknown): packet is AnyPacket<TIncoming, TService> {
+export type MethodPacket = MethodRequestPacket;
+
+// Typed packet variants for use in subclass typed event APIs.
+// These are structurally assignable to AnyPacket so existing
+// runtime/transport code that operates on AnyPacket continues to work.
+
+export interface MethodRequestPacket extends RequestPacket {
+	ackTimeoutMs?: boolean | number,
+	data?: unknown,
+	method: string
+}
+
+interface RequestPacket {
+	cid?: number
+}
+
+export type ServicePacket = ServiceRequestPacket;
+
+export interface ServiceRequestPacket extends RequestPacket {
+	ackTimeoutMs?: boolean | number,
+	data?: unknown,
+	method: string,
+	service: string
+}
+
+export function isRequestPacket(packet: unknown): packet is AnyPacket {
 	return (
 		packet !== null
 		&& typeof packet === 'object'

--- a/packages/core/src/packet.ts
+++ b/packages/core/src/packet.ts
@@ -64,6 +64,11 @@ export interface ServiceRequestPacket extends RequestPacket {
 	service: string
 }
 
+export function isRequestPacket(packet: unknown): packet is AnyPacket;
+export function isRequestPacket<
+	TIncoming extends MethodMap,
+	TService extends ServiceMap = {}
+>(packet: unknown): packet is IncomingPacket<TIncoming, TService>;
 export function isRequestPacket(packet: unknown): packet is AnyPacket {
 	return (
 		packet !== null

--- a/packages/core/src/plugins/plugin.ts
+++ b/packages/core/src/plugins/plugin.ts
@@ -85,8 +85,8 @@ export interface SendRequestPluginArgs<
 	TService extends ServiceMap,
 	TState extends object
 > extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
-	cont: (requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[]) => void,
-	requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[]
+	cont: (requests: AnyRequest[]) => void,
+	requests: AnyRequest[]
 }
 
 export interface SendResponsePluginArgs<

--- a/packages/core/src/plugins/plugin.ts
+++ b/packages/core/src/plugins/plugin.ts
@@ -1,101 +1,81 @@
 import ws from 'isomorphic-ws';
 
-import { HandlerMap } from '../maps/handler-map.js';
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from '../maps/method-map.js';
 import { AnyPacket } from '../packet.js';
+import { LooseHandlerMap } from '../request-handler.js';
 import { AnyRequest } from '../request.js';
 import { AnyResponse } from '../response.js';
-import { SocketTransport } from '../socket-transport.js';
-import { Socket, SocketStatus } from '../socket.js';
+import { BaseSocketTransport } from '../socket-transport.js';
+import { BaseSocket, SocketStatus } from '../socket.js';
+
+export type AnyPlugin = Plugin<any, any>;
 
 export interface DisconnectedPluginArgs<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
+> extends PluginArgs<TSocket, TTransport> {
 	code: number,
 	reason?: string,
 	status: SocketStatus
 }
 
 export interface MessagePluginArgs<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
+> extends PluginArgs<TSocket, TTransport> {
 	packet: AnyPacket | AnyResponse,
 	timestamp: Date
 }
 
 export interface MessageRawPluginArgs<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
+> extends PluginArgs<TSocket, TTransport> {
 	message: string | ws.RawData,
 	promise: Promise<void>,
 	timestamp: Date
 }
 
 export interface Plugin<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
 > {
-	handlers?: HandlerMap<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
-	onAuthenticated?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onClose?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onDeauthenticate?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onDisconnected?(options: DisconnectedPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onEnd?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onMessage?(options: MessagePluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): Promise<AnyPacket | AnyResponse>,
-	onMessageRaw?(options: MessageRawPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): Promise<string | ws.RawData>,
-	onOpen?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onReady?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	sendRequest?(options: SendRequestPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	sendResponse?(options: SendResponsePluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
+	handlers?: LooseHandlerMap,
+	onAuthenticated?(options: PluginArgs<TSocket, TTransport>): void,
+	onClose?(options: PluginArgs<TSocket, TTransport>): void,
+	onDeauthenticate?(options: PluginArgs<TSocket, TTransport>): void,
+	onDisconnected?(options: DisconnectedPluginArgs<TSocket, TTransport>): void,
+	onEnd?(options: PluginArgs<TSocket, TTransport>): void,
+	onMessage?(options: MessagePluginArgs<TSocket, TTransport>): Promise<AnyPacket | AnyResponse>,
+	onMessageRaw?(options: MessageRawPluginArgs<TSocket, TTransport>): Promise<string | ws.RawData>,
+	onOpen?(options: PluginArgs<TSocket, TTransport>): void,
+	onReady?(options: PluginArgs<TSocket, TTransport>): void,
+	sendRequest?(options: SendRequestPluginArgs<TSocket, TTransport>): void,
+	sendResponse?(options: SendResponsePluginArgs<TSocket, TTransport>): void,
 	type: string
 }
 
 export interface PluginArgs<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
 > {
-	socket: Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
-	transport: SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>
+	socket: TSocket,
+	transport: TTransport
 }
 
 export type PluginType = 'handshake' | 'request' | 'response';
 
 export interface SendRequestPluginArgs<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
+> extends PluginArgs<TSocket, TTransport> {
 	cont: (requests: AnyRequest[]) => void,
 	requests: AnyRequest[]
 }
 
 export interface SendResponsePluginArgs<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+	TSocket extends BaseSocket = BaseSocket,
+	TTransport extends BaseSocketTransport = BaseSocketTransport
+> extends PluginArgs<TSocket, TTransport> {
 	cont: (requests: AnyResponse[]) => void,
 	responses: AnyResponse[]
 }

--- a/packages/core/src/plugins/plugin.ts
+++ b/packages/core/src/plugins/plugin.ts
@@ -27,7 +27,7 @@ export interface MessagePluginArgs<
 	TService extends ServiceMap,
 	TState extends object
 > extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
-	packet: AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>,
+	packet: AnyPacket | AnyResponse,
 	timestamp: Date
 }
 
@@ -56,7 +56,7 @@ export interface Plugin<
 	onDeauthenticate?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
 	onDisconnected?(options: DisconnectedPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
 	onEnd?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
-	onMessage?(options: MessagePluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): Promise<AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>>,
+	onMessage?(options: MessagePluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): Promise<AnyPacket | AnyResponse>,
 	onMessageRaw?(options: MessageRawPluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): Promise<string | ws.RawData>,
 	onOpen?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
 	onReady?(options: PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>): void,
@@ -96,6 +96,6 @@ export interface SendResponsePluginArgs<
 	TService extends ServiceMap,
 	TState extends object
 > extends PluginArgs<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
-	cont: (requests: AnyResponse<TOutgoing, TPrivateOutgoing, TService>[]) => void,
-	responses: AnyResponse<TOutgoing, TPrivateOutgoing, TService>[]
+	cont: (requests: AnyResponse[]) => void,
+	responses: AnyResponse[]
 }

--- a/packages/core/src/request-handler.ts
+++ b/packages/core/src/request-handler.ts
@@ -1,29 +1,24 @@
 import { TimeoutError } from '@socket-mesh/errors';
 
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
-import { SocketTransport } from './socket-transport.js';
-import { Socket } from './socket.js';
+import { BaseSocketTransport } from './socket-transport.js';
+import { BaseSocket } from './socket.js';
+
+export interface LooseHandlerMap {
+	[method: string]: ((args: RequestHandlerArgs<any, any, any, any>) => Promise<any>) | undefined
+}
 
 export type RequestHandler<
 	TOptions, U,
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
 	TState extends object,
-	TSocket extends Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> = Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
-	TTransport extends SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> = SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>
-> = (args: RequestHandlerArgs<TOptions, TIncoming, TOutgoing, TPrivateOutgoing, TService, TState, TSocket, TTransport>) => Promise<U>;
+	TSocket extends BaseSocket<TState> = BaseSocket<TState>,
+	TTransport extends BaseSocketTransport<TState> = BaseSocketTransport<TState>
+> = (args: RequestHandlerArgs<TOptions, TState, TSocket, TTransport>) => Promise<U>;
 
 export interface RequestHandlerArgsOptions<
 	TOptions,
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
 	TState extends object,
-	TSocket extends Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> = Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
-	TTransport extends SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> = SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>
+	TSocket extends BaseSocket<TState> = BaseSocket<TState>,
+	TTransport extends BaseSocketTransport<TState> = BaseSocketTransport<TState>
 > {
 	isRpc: boolean,
 	method: string,
@@ -35,13 +30,9 @@ export interface RequestHandlerArgsOptions<
 
 export class RequestHandlerArgs<
 	TOptions,
-	TIncoming extends MethodMap = {},
-	TOutgoing extends PublicMethodMap = {},
-	TPrivateOutgoing extends PrivateMethodMap = {},
-	TService extends ServiceMap = {},
 	TState extends object = {},
-	TSocket extends Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> = Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
-	TTransport extends SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> = SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>
+	TSocket extends BaseSocket<TState> = BaseSocket<TState>,
+	TTransport extends BaseSocketTransport<TState> = BaseSocketTransport<TState>
 > {
 	public isRpc: boolean;
 	public method: string;
@@ -51,7 +42,7 @@ export class RequestHandlerArgs<
 	public timeoutMs?: boolean | number;
 	public transport: TTransport;
 
-	constructor(options: RequestHandlerArgsOptions<TOptions, TIncoming, TOutgoing, TPrivateOutgoing, TService, TState, TSocket, TTransport>) {
+	constructor(options: RequestHandlerArgsOptions<TOptions, TState, TSocket, TTransport>) {
 		this.isRpc = options.isRpc;
 		this.method = options.method;
 		this.options = options.options;

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,60 +1,42 @@
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
 import { toArray } from './utils.js';
 
-export type AnyRequest<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
-> =
-	MethodRequest<TOutgoing> | MethodRequest<TPrivateOutgoing> | ServiceRequest<TService>;
+export type AnyRequest = MethodRequest | ServiceRequest;
 
-export interface InvokeMethodRequest<TMethodMap extends MethodMap, TMethod extends keyof TMethodMap> extends TransmitMethodRequest<TMethodMap, TMethod> {
+export interface InvokeMethodRequest extends TransmitMethodRequest {
 	ackTimeoutMs: false | number,
-	callback: ((err: Error | null, result?: TMethodMap[TMethod]) => void) | null,
+	callback: ((err: Error | null, result?: unknown) => void) | null,
 	cid: number,
 	timeoutId?: NodeJS.Timeout
 }
 
-export interface InvokeServiceRequest<TServiceMap extends ServiceMap, TService extends keyof TServiceMap, TMethod extends keyof TServiceMap[TService]> extends TransmitServiceRequest<TServiceMap, TService, TMethod> {
+export interface InvokeServiceRequest extends TransmitServiceRequest {
 	ackTimeoutMs: false | number,
-	callback: ((err: Error | null, result?: TServiceMap[TService][TMethod]) => void) | null,
+	callback: ((err: Error | null, result?: unknown) => void) | null,
 	cid: number,
 	timeoutId?: NodeJS.Timeout
 }
 
-export type MethodRequest<TMethodMap extends MethodMap> =
-	{ [TMethod in keyof TMethodMap]:
-		InvokeMethodRequest<TMethodMap, TMethod> | TransmitMethodRequest<TMethodMap, TMethod>
-	}[keyof TMethodMap];
+export type MethodRequest = InvokeMethodRequest | TransmitMethodRequest;
 
 export interface Request {
 	promise: Promise<void>,
 	sentCallback?: (err?: Error) => void
 }
 
-export type ServiceRequest<TServiceMap extends ServiceMap> =
-	{ [TService in keyof TServiceMap]:
-		{ [TMethod in keyof TServiceMap[TService]]:
-			InvokeServiceRequest<TServiceMap, TService, TMethod> | TransmitServiceRequest<TServiceMap, TService, TMethod>
-		}[keyof TServiceMap[TService]]
-	}[keyof TServiceMap];
+export type ServiceRequest = InvokeServiceRequest | TransmitServiceRequest;
 
-export interface TransmitMethodRequest<TMethodMap extends MethodMap, TMethod extends keyof TMethodMap> extends Request {
-	data?: Parameters<TMethodMap[TMethod]>[0],
-	method: TMethod
+export interface TransmitMethodRequest extends Request {
+	data?: unknown,
+	method: string
 }
 
-export interface TransmitServiceRequest<TServiceMap extends ServiceMap, TService extends keyof TServiceMap, TMethod extends keyof TServiceMap[TService]> extends Request {
-	data?: Parameters<TServiceMap[TService][TMethod]>[0],
-	method: TMethod,
-	service: TService
+export interface TransmitServiceRequest extends Request {
+	data?: unknown,
+	method: string,
+	service: string
 }
 
-export function abortRequest<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
->(request: AnyRequest<TOutgoing, TPrivateOutgoing, TService>, err: Error): void {
+export function abortRequest(request: AnyRequest, err: Error): void {
 	if (request.sentCallback) {
 		request.sentCallback(err);
 	}
@@ -64,11 +46,7 @@ export function abortRequest<
 	}
 }
 
-export function isRequestDone<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
->(request: AnyRequest<TOutgoing, TPrivateOutgoing, TService>): boolean {
+export function isRequestDone(request: AnyRequest): boolean {
 	if ('callback' in request) {
 		return (request.callback === null);
 	}
@@ -76,16 +54,12 @@ export function isRequestDone<
 	return !request.sentCallback;
 }
 
-export class RequestCollection<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
-> {
+export class RequestCollection {
 	private readonly _callbacks: (() => void)[];
-	private readonly _requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService>[];
+	private readonly _requests: AnyRequest[];
 
-	constructor(requests: AnyRequest<TOutgoing, TPrivateOutgoing, TService> | AnyRequest<TOutgoing, TPrivateOutgoing, TService>[]) {
-		this._requests = toArray(requests).filter(req => !isRequestDone<TOutgoing, TPrivateOutgoing, TService>(req));
+	constructor(requests: AnyRequest | AnyRequest[]) {
+		this._requests = toArray(requests).filter(req => !isRequestDone(req));
 		this._callbacks = [];
 	}
 
@@ -93,7 +67,7 @@ export class RequestCollection<
 		return this._requests.length === 0;
 	}
 
-	public get items(): ReadonlyArray<AnyRequest<TOutgoing, TPrivateOutgoing, TService>> {
+	public get items(): ReadonlyArray<AnyRequest> {
 		return this._requests;
 	}
 

--- a/packages/core/src/response.ts
+++ b/packages/core/src/response.ts
@@ -1,45 +1,55 @@
 import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
 
-export type AnyResponse<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
-> =
-	ErrorResponse | MethodDataResponse<TOutgoing> | MethodDataResponse<TPrivateOutgoing> | Response | ServiceDataResponse<TService>;
+export type AnyResponse = DataResponse | ErrorResponse | Response;
 
-export interface DataResponse<T> extends Response {
-	data: T
+export interface DataResponse extends Response {
+	data: unknown
 }
 
 export interface ErrorResponse extends Response {
 	error: Error
 }
 
-export type MethodDataResponse<TMethodMap extends MethodMap> =
+export interface OutgoingDataResponse<T> extends Response {
+	data: T
+}
+
+export type OutgoingMethodDataResponse<TMethodMap extends MethodMap> =
 	{ [TMethod in keyof TMethodMap]:
-		DataResponse<ReturnType<TMethodMap[TMethod]>>
+		OutgoingDataResponse<ReturnType<TMethodMap[TMethod]>>
 	}[keyof TMethodMap];
+
+// Typed response variants for use in subclass typed event APIs.
+// These are structurally assignable to AnyResponse so existing
+// runtime/transport code that operates on AnyResponse continues to work.
+
+export type OutgoingResponse<
+	TOutgoing extends PublicMethodMap,
+	TPrivateOutgoing extends PrivateMethodMap,
+	TService extends ServiceMap
+> =
+	ErrorResponse
+	| OutgoingMethodDataResponse<TOutgoing>
+	| OutgoingMethodDataResponse<TPrivateOutgoing>
+	| OutgoingServiceDataResponse<TService>
+	| Response;
+
+export type OutgoingServiceDataResponse<TServiceMap extends ServiceMap> =
+	{ [TService in keyof TServiceMap]:
+		{ [TMethod in keyof TServiceMap[TService]]:
+			OutgoingDataResponse<ReturnType<TServiceMap[TService][TMethod]>>
+		}[keyof TServiceMap[TService]]
+	}[keyof TServiceMap];
 
 export interface Response {
 	rid: number,
 	timeoutAt?: Date
 }
 
-export type ServiceDataResponse<TServiceMap extends ServiceMap> =
-	{ [TService in keyof TServiceMap]:
-		{ [TMethod in keyof TServiceMap[TService]]:
-			DataResponse<ReturnType<TServiceMap[TService][TMethod]>>
-		}[keyof TServiceMap[TService]]
-	}[keyof TServiceMap];
-
-export function isResponsePacket<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
->(packet?: unknown): packet is AnyResponse<TOutgoing, TPrivateOutgoing, TService> {
+export function isResponsePacket(packet?: unknown): packet is AnyResponse {
 	return (
 		packet !== null
 		&& typeof packet === 'object'
-		&& 'rid' in packet
+		&& 'rid' in (packet as object)
 	);
 }

--- a/packages/core/src/socket-event.ts
+++ b/packages/core/src/socket-event.ts
@@ -2,8 +2,8 @@ import { AuthToken, SignedAuthToken } from '@socket-mesh/auth';
 import ws from 'isomorphic-ws';
 
 import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
-import { MethodPacket, ServicePacket } from './packet.js';
-import { AnyResponse } from './response.js';
+import { AnyPacket, IncomingPacket } from './packet.js';
+import { AnyResponse, OutgoingResponse } from './response.js';
 
 export interface AuthenticatedChangeEvent {
 	authToken: AuthToken | null,
@@ -72,25 +72,29 @@ export interface RemoveAuthTokenEvent {
 }
 
 export interface RequestEvent<
-	TIncoming extends MethodMap,
-	TService extends ServiceMap
+	TIncoming extends MethodMap = never,
+	TService extends ServiceMap = never
 > {
-	request: MethodPacket<TIncoming> | ServicePacket<TService>
+	request: [TIncoming] extends [never]
+		? AnyPacket
+		: IncomingPacket<TIncoming, TService>
 }
 
 export interface ResponseEvent<
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
+	TOutgoing extends PublicMethodMap = never,
+	TPrivateOutgoing extends PrivateMethodMap = never,
+	TService extends ServiceMap = never
 > {
-	response: AnyResponse<TOutgoing, TPrivateOutgoing, TService>
+	response: [TOutgoing] extends [never]
+		? AnyResponse
+		: OutgoingResponse<TOutgoing, TPrivateOutgoing, TService>
 }
 
 export type SocketEvent<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
+	TIncoming extends MethodMap = never,
+	TOutgoing extends PublicMethodMap = never,
+	TPrivateOutgoing extends PrivateMethodMap = never,
+	TService extends ServiceMap = never
 > =
 	AuthenticateEvent
 	| AuthStateChangeEvent

--- a/packages/core/src/socket-event.ts
+++ b/packages/core/src/socket-event.ts
@@ -71,30 +71,51 @@ export interface RemoveAuthTokenEvent {
 	oldAuthToken: SignedAuthToken
 }
 
-export interface RequestEvent<
-	TIncoming extends MethodMap = never,
-	TService extends ServiceMap = never
-> {
-	request: [TIncoming] extends [never]
-		? AnyPacket
-		: IncomingPacket<TIncoming, TService>
+export interface RequestEvent {
+	request: AnyPacket
 }
 
-export interface ResponseEvent<
-	TOutgoing extends PublicMethodMap = never,
-	TPrivateOutgoing extends PrivateMethodMap = never,
-	TService extends ServiceMap = never
-> {
-	response: [TOutgoing] extends [never]
-		? AnyResponse
-		: OutgoingResponse<TOutgoing, TPrivateOutgoing, TService>
+export interface ResponseEvent {
+	response: AnyResponse
 }
 
-export type SocketEvent<
-	TIncoming extends MethodMap = never,
-	TOutgoing extends PublicMethodMap = never,
-	TPrivateOutgoing extends PrivateMethodMap = never,
-	TService extends ServiceMap = never
+export type SocketEvent =
+	AuthenticateEvent
+	| AuthStateChangeEvent
+	| BadAuthTokenEvent
+	| CloseEvent
+	| ConnectEvent
+	| ConnectingEvent
+	| DeauthenticateEvent
+	| DisconnectEvent
+	| ErrorEvent
+	| MessageEvent
+	| PingEvent
+	| PongEvent
+	| RemoveAuthTokenEvent
+	| RequestEvent
+	| ResponseEvent;
+
+export interface TypedRequestEvent<
+	TIncoming extends MethodMap,
+	TService extends ServiceMap = {}
+> {
+	request: IncomingPacket<TIncoming, TService>
+}
+
+export interface TypedResponseEvent<
+	TOutgoing extends PublicMethodMap,
+	TPrivateOutgoing extends PrivateMethodMap = {},
+	TService extends ServiceMap = {}
+> {
+	response: OutgoingResponse<TOutgoing, TPrivateOutgoing, TService>
+}
+
+export type TypedSocketEvent<
+	TIncoming extends MethodMap,
+	TOutgoing extends PublicMethodMap,
+	TPrivateOutgoing extends PrivateMethodMap = {},
+	TService extends ServiceMap = {}
 > =
 	AuthenticateEvent
 	| AuthStateChangeEvent
@@ -109,5 +130,5 @@ export type SocketEvent<
 	| PingEvent
 	| PongEvent
 	| RemoveAuthTokenEvent
-	| RequestEvent<TIncoming, TService>
-	| ResponseEvent<TOutgoing, TPrivateOutgoing, TService>;
+	| TypedRequestEvent<TIncoming, TService>
+	| TypedResponseEvent<TOutgoing, TPrivateOutgoing, TService>;

--- a/packages/core/src/socket-transport.ts
+++ b/packages/core/src/socket-transport.ts
@@ -223,8 +223,8 @@ export class SocketTransport<
 		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
 		arg?: unknown
 	): [Promise<unknown>, () => void] {
-		let methodRequest: Omit<InvokeMethodRequest<any, any>, 'promise'> | undefined;
-		let serviceRequest: Omit<InvokeServiceRequest<any, any, any>, 'promise'> | undefined;
+		let methodRequest: Omit<InvokeMethodRequest, 'promise'> | undefined;
+		let serviceRequest: Omit<InvokeServiceRequest, 'promise'> | undefined;
 		let service: string | undefined;
 		let ackTimeoutMs: false | number | undefined;
 
@@ -322,7 +322,7 @@ export class SocketTransport<
 
 		const request = Object.assign(baseRequest, { promise });
 
-		this.onInvoke(request as AnyRequest<TOutgoing, TPrivateOutgoing, TService>);
+		this.onInvoke(request as AnyRequest);
 
 		return [promise, abort!];
 	}
@@ -381,7 +381,7 @@ export class SocketTransport<
 		this._socket.emit('error', { error });
 	}
 
-	protected onInvoke(request: AnyRequest<TOutgoing, TPrivateOutgoing, TService>): void {
+	protected onInvoke(request: AnyRequest): void {
 		this.sendRequest([request]);
 	}
 
@@ -545,7 +545,7 @@ export class SocketTransport<
 		this.onMessage(event.data, false);
 	}
 
-	protected onTransmit(request: AnyRequest<TOutgoing, TPrivateOutgoing, TService>): void {
+	protected onTransmit(request: AnyRequest): void {
 		this.sendRequest([request]);
 	}
 
@@ -593,9 +593,9 @@ export class SocketTransport<
 		});
 	}
 
-	protected sendRequest(requests: (AnyRequest<TOutgoing, TPrivateOutgoing, TService>)[]): void;
-	protected sendRequest(index: number, requests: (AnyRequest<TOutgoing, TPrivateOutgoing, TService>)[]): void;
-	protected sendRequest(index: (AnyRequest<TOutgoing, TPrivateOutgoing, TService>)[] | number, requests?: (AnyRequest<TOutgoing, TPrivateOutgoing, TService>)[]): void {
+	protected sendRequest(requests: AnyRequest[]): void;
+	protected sendRequest(index: number, requests: AnyRequest[]): void;
+	protected sendRequest(index: AnyRequest[] | number, requests?: AnyRequest[]): void {
 		if (typeof index === 'object') {
 			requests = index;
 			index = 0;
@@ -843,8 +843,8 @@ export class SocketTransport<
 		serviceAndMethod: [string, string] | string,
 		arg?: unknown
 	): Promise<void> {
-		let serviceRequest: Omit<TransmitServiceRequest<any, any, any>, 'promise'> | undefined;
-		let methodRequest: Omit<TransmitMethodRequest<any, any>, 'promise'> | undefined;
+		let serviceRequest: Omit<TransmitServiceRequest, 'promise'> | undefined;
+		let methodRequest: Omit<TransmitMethodRequest, 'promise'> | undefined;
 
 		if (Array.isArray(serviceAndMethod)) {
 			serviceRequest = {
@@ -879,7 +879,7 @@ export class SocketTransport<
 
 		const request = Object.assign(baseRequest, { promise });
 
-		this.onTransmit(request as AnyRequest<TOutgoing, TPrivateOutgoing, TService>);
+		this.onTransmit(request as AnyRequest);
 
 		return request.promise;
 	}

--- a/packages/core/src/socket-transport.ts
+++ b/packages/core/src/socket-transport.ts
@@ -5,25 +5,20 @@ import ws from 'isomorphic-ws';
 
 import { HandlerMap } from './maps/handler-map.js';
 import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
-import { AnyPacket, isRequestPacket, MethodPacket } from './packet.js';
+import { AnyPacket, isRequestPacket } from './packet.js';
 import { Plugin } from './plugins/plugin.js';
 import { RequestHandlerArgs } from './request-handler.js';
 import { abortRequest, AnyRequest, InvokeMethodRequest, InvokeServiceRequest, isRequestDone, TransmitMethodRequest, TransmitServiceRequest } from './request.js';
-import { AnyResponse, isResponsePacket, MethodDataResponse } from './response.js';
+import { AnyResponse, DataResponse, isResponsePacket } from './response.js';
 import { Socket, SocketOptions, SocketStatus, StreamCleanupMode } from './socket.js';
 import { toArray, toError, wait } from './utils.js';
 
 export type CallIdGenerator = () => number;
 
-export interface InboundMessage<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap
-> {
+export interface InboundMessage {
 	packet:
-		(AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>)[]
-		| (AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>) | null,
+		(AnyPacket | AnyResponse)[]
+		| (AnyPacket | AnyResponse) | null,
 	timestamp: Date
 }
 
@@ -188,12 +183,12 @@ export class SocketTransport<
 		return this._outboundPreparedMessageCount - this._outboundSentMessageCount;
 	}
 
-	protected async handleInboudMessage({ packet, timestamp }: InboundMessage<TIncoming, TOutgoing, TPrivateOutgoing, TService>): Promise<void> {
+	protected async handleInboudMessage({ packet, timestamp }: InboundMessage): Promise<void> {
 		if (packet === null) {
 			return;
 		}
 
-		packet = toArray<AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>>(packet);
+		packet = toArray<AnyPacket | AnyResponse>(packet);
 
 		for (let curPacket of packet) {
 			let pluginError: Error | undefined;
@@ -417,8 +412,8 @@ export class SocketTransport<
 
 		p.then((data) => {
 			const packet:
-				(AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>)[]
-				| (AnyPacket<TIncoming, TService> | AnyResponse<TOutgoing, TPrivateOutgoing, TService>)
+				(AnyPacket | AnyResponse)[]
+				| (AnyPacket | AnyResponse)
 				| null = this.decode(data);
 
 			this._socket.emit('message', { data, isBinary });
@@ -446,13 +441,13 @@ export class SocketTransport<
 
 	protected onPingPong(): void {}
 
-	protected async onRequest(packet: AnyPacket<TIncoming, TService>, timestamp: Date, pluginError?: Error): Promise<boolean> {
+	protected async onRequest(packet: AnyPacket, timestamp: Date, pluginError?: Error): Promise<boolean> {
 		this._socket.emit('request', { request: packet });
 
 		const timeoutAt = typeof packet.ackTimeoutMs === 'number' ? new Date(timestamp.valueOf() + packet.ackTimeoutMs) : undefined;
 		let wasHandled = false;
 
-		let response: AnyResponse<TOutgoing, TPrivateOutgoing, TService> | undefined;
+		let response: AnyResponse | undefined;
 		let error: Error | undefined;
 
 		if (pluginError) {
@@ -463,7 +458,7 @@ export class SocketTransport<
 				response = { error: pluginError, rid: packet.cid, timeoutAt };
 			}
 		} else {
-			const handler = this._handlers[(packet as MethodPacket<TIncoming>).method];
+			const handler = this._handlers[packet.method as keyof TIncoming];
 
 			if (handler) {
 				wasHandled = true;
@@ -472,7 +467,7 @@ export class SocketTransport<
 					const data = await handler(
 						new RequestHandlerArgs({
 							isRpc: !!packet.cid,
-							method: packet.method.toString(),
+							method: packet.method,
 							options: packet.data,
 							socket: this._socket,
 							timeoutMs: packet.ackTimeoutMs,
@@ -481,7 +476,7 @@ export class SocketTransport<
 					);
 
 					if (packet.cid) {
-						response = { data, rid: packet.cid, timeoutAt } as MethodDataResponse<TIncoming>;
+						response = { data, rid: packet.cid, timeoutAt } as DataResponse;
 					}
 				} catch (err) {
 					error = toError(err);
@@ -508,7 +503,7 @@ export class SocketTransport<
 		return wasHandled;
 	}
 
-	protected onResponse(response: AnyResponse<TOutgoing, TPrivateOutgoing, TService>, pluginError?: Error) {
+	protected onResponse(response: AnyResponse, pluginError?: Error) {
 		const map = this._callbackMap[response.rid];
 
 		if (map) {
@@ -549,7 +544,7 @@ export class SocketTransport<
 		this.sendRequest([request]);
 	}
 
-	protected onUnhandledRequest(_: AnyPacket<TIncoming, TService>): boolean {
+	protected onUnhandledRequest(_: AnyPacket): boolean {
 		return false;
 	}
 
@@ -702,9 +697,9 @@ export class SocketTransport<
 		});
 	}
 
-	protected sendResponse(responses: (AnyResponse<TOutgoing, TPrivateOutgoing, TService>)[]): void;
-	protected sendResponse(index: number, responses: (AnyResponse<TOutgoing, TPrivateOutgoing, TService>)[]): void;
-	protected sendResponse(index: (AnyResponse<TOutgoing, TPrivateOutgoing, TService>)[] | number, responses?: (AnyResponse<TOutgoing, TPrivateOutgoing, TService>)[]): void {
+	protected sendResponse(responses: AnyResponse[]): void;
+	protected sendResponse(index: number, responses: AnyResponse[]): void;
+	protected sendResponse(index: AnyResponse[] | number, responses?: AnyResponse[]): void {
 		if (typeof index === 'object') {
 			responses = index;
 			index = 0;

--- a/packages/core/src/socket-transport.ts
+++ b/packages/core/src/socket-transport.ts
@@ -3,14 +3,16 @@ import { AbortError, AuthError, BadConnectionError, dehydrateError, hydrateError
 import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
 import ws from 'isomorphic-ws';
 
-import { HandlerMap } from './maps/handler-map.js';
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
+import {
+	FunctionReturnType, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName,
+	ServiceName
+} from './maps/method-map.js';
 import { AnyPacket, isRequestPacket } from './packet.js';
-import { Plugin } from './plugins/plugin.js';
-import { RequestHandlerArgs } from './request-handler.js';
+import { AnyPlugin } from './plugins/plugin.js';
+import { LooseHandlerMap, RequestHandlerArgs } from './request-handler.js';
 import { abortRequest, AnyRequest, InvokeMethodRequest, InvokeServiceRequest, isRequestDone, TransmitMethodRequest, TransmitServiceRequest } from './request.js';
 import { AnyResponse, DataResponse, isResponsePacket } from './response.js';
-import { Socket, SocketOptions, SocketStatus, StreamCleanupMode } from './socket.js';
+import { BaseSocket, BaseSocketOptions, Socket, SocketStatus, StreamCleanupMode } from './socket.js';
 import { toArray, toError, wait } from './utils.js';
 
 export type CallIdGenerator = () => number;
@@ -46,21 +48,55 @@ export interface InvokeServiceOptions<
 	service: TService
 }
 
+export type SocketTransport<
+	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
+	TService extends ServiceMap = {},
+	TPrivateIncoming extends PrivateMethodMap = {},
+	TPrivateOutgoing extends PrivateMethodMap = {}
+> = Omit<BaseSocketTransport<TState>, 'invoke' | 'socket' | 'transmit'> & {
+	invoke<TMethod extends keyof TOutgoing & string>(
+		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]
+	): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void],
+	invoke<TMethod extends keyof TOutgoing & string>(
+		options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]
+	): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void],
+	invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
+		options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]
+	): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void],
+	invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
+		options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]
+	): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void],
+	invoke<TMethod extends keyof TPrivateOutgoing & string>(
+		method: TMethod, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]
+	): [Promise<FunctionReturnType<TPrivateOutgoing[TMethod]>>, () => void],
+	invoke<TMethod extends keyof TPrivateOutgoing & string>(
+		options: InvokeMethodOptions<TPrivateOutgoing, TMethod>, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]
+	): [Promise<FunctionReturnType<TPrivateOutgoing[TMethod]>>, () => void],
+
+	readonly socket: Socket<TIncoming, TOutgoing, TState, TService, TPrivateIncoming, TPrivateOutgoing>,
+
+	transmit<TMethod extends keyof TOutgoing & string>(
+		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]
+	): Promise<void>,
+	transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
+		options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]
+	): Promise<void>,
+	transmit<TMethod extends keyof TPrivateOutgoing & string>(
+		method: TMethod, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]
+	): Promise<void>
+};
+
 interface WebSocketError extends Error {
 	code?: string
 }
 
-export class SocketTransport<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> {
+export class BaseSocketTransport<TState extends object = {}> {
 	private _authToken: AuthToken | null;
 	private readonly _callbackMap: { [cid: number]: InvokeCallback<unknown> };
 	private readonly _callIdGenerator: CallIdGenerator;
-	private readonly _handlers: HandlerMap<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>;
+	private readonly _handlers: LooseHandlerMap;
 	private _inboundProcessedMessageCount: number;
 	private _inboundReceivedMessageCount: number;
 	private _isReady: boolean;
@@ -68,16 +104,16 @@ export class SocketTransport<
 	private _outboundSentMessageCount: number;
 	private _pingTimeoutRef: NodeJS.Timeout | null;
 	private _signedAuthToken: null | SignedAuthToken;
-	private _socket!: Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>;
+	private _socket!: BaseSocket<TState>;
 	private _webSocket: null | ws.WebSocket;
 	public ackTimeoutMs: number;
 	public readonly codecEngine: CodecEngine;
 	public id: null | string;
-	public readonly plugins: Plugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>[];
+	public readonly plugins: AnyPlugin[];
 
 	public streamCleanupMode: StreamCleanupMode;
 
-	protected constructor(options?: SocketOptions<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>) {
+	protected constructor(options?: BaseSocketOptions<TState>) {
 		let cid = 1;
 
 		this._isReady = false;
@@ -458,7 +494,7 @@ export class SocketTransport<
 				response = { error: pluginError, rid: packet.cid, timeoutAt };
 			}
 		} else {
-			const handler = this._handlers[packet.method as keyof TIncoming];
+			const handler = this._handlers[packet.method];
 
 			if (handler) {
 				wasHandled = true;
@@ -805,11 +841,11 @@ export class SocketTransport<
 		return this._signedAuthToken;
 	}
 
-	public get socket(): Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState> {
+	public get socket(): BaseSocket<TState> {
 		return this._socket;
 	}
 
-	public set socket(value: Socket<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>) {
+	public set socket(value: BaseSocket<TState>) {
 		this._socket = value;
 	}
 

--- a/packages/core/src/socket-transport.ts
+++ b/packages/core/src/socket-transport.ts
@@ -4,7 +4,7 @@ import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
 import ws from 'isomorphic-ws';
 
 import { HandlerMap } from './maps/handler-map.js';
-import { FunctionReturnType, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName } from './maps/method-map.js';
+import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
 import { AnyPacket, isRequestPacket, MethodPacket } from './packet.js';
 import { Plugin } from './plugins/plugin.js';
 import { RequestHandlerArgs } from './request-handler.js';
@@ -33,12 +33,19 @@ interface InvokeCallback<T> {
 	timeoutId?: NodeJS.Timeout
 }
 
-export interface InvokeMethodOptions<TMethodMap extends MethodMap, TMethod extends keyof TMethodMap> {
+export interface InvokeMethodOptions<
+	TMethodMap extends MethodMap = MethodMap,
+	TMethod extends keyof TMethodMap & string = keyof TMethodMap & string
+> {
 	ackTimeoutMs?: false | number,
 	method: TMethod
 }
 
-export interface InvokeServiceOptions<TServiceMap extends ServiceMap, TService extends keyof TServiceMap, TMethod extends keyof TServiceMap[TService]> {
+export interface InvokeServiceOptions<
+	TServiceMap extends ServiceMap = ServiceMap,
+	TService extends keyof TServiceMap & string = keyof TServiceMap & string,
+	TMethod extends keyof TServiceMap[TService] & string = keyof TServiceMap[TService] & string
+> {
 	ackTimeoutMs?: false | number,
 	method: TMethod,
 	service: TService
@@ -212,30 +219,13 @@ export class SocketTransport<
 		}
 	}
 
-	public invoke<TMethod extends keyof TOutgoing>(
-		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void];
-	public invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
-		options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void];
-	public invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
-		options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void];
-	public invoke<TMethod extends keyof TOutgoing>(
-		options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void];
-	public invoke<TMethod extends keyof TPrivateOutgoing>(
-		method: TMethod, arg: Parameters<TPrivateOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TPrivateOutgoing[TMethod]>>, () => void];
-	public invoke<TMethod extends keyof TPrivateOutgoing>(
-		options: InvokeMethodOptions<TPrivateOutgoing, TMethod>, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TPrivateOutgoing[TMethod]>>, () => void];
-	public invoke<
-		TServiceName extends ServiceName<TService>,
-		TServiceMethod extends ServiceMethodName<TService, TServiceName>,
-		TMethod extends keyof TOutgoing,
-		TPrivateMethod extends keyof TPrivateOutgoing
-	>(
-		methodOptions: [TServiceName, TServiceMethod, (false | number)?] | InvokeMethodOptions<TOutgoing, TMethod> | InvokeMethodOptions<TPrivateOutgoing, TPrivateMethod> | InvokeServiceOptions<TService, TServiceName, TServiceMethod> | TMethod | TPrivateMethod,
-		arg?: (Parameters<TOutgoing[TMethod] | TPrivateOutgoing[TPrivateMethod] | TService[TServiceName][TServiceMethod]>)[0]
-	): [Promise<FunctionReturnType<TOutgoing[TMethod] | TPrivateOutgoing[TPrivateMethod] | TService[TServiceName][TServiceMethod]>>, () => void] {
-		let methodRequest: Omit<InvokeMethodRequest<TOutgoing, TMethod>, 'promise'> | Omit<InvokeMethodRequest<TPrivateOutgoing, TPrivateMethod>, 'promise'> | undefined;
-		let serviceRequest: Omit<InvokeServiceRequest<TService, TServiceName, TServiceMethod>, 'promise'> | undefined;
-		let service: TServiceName | undefined;
+	public invoke(
+		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
+		arg?: unknown
+	): [Promise<unknown>, () => void] {
+		let methodRequest: Omit<InvokeMethodRequest<any, any>, 'promise'> | undefined;
+		let serviceRequest: Omit<InvokeServiceRequest<any, any, any>, 'promise'> | undefined;
+		let service: string | undefined;
 		let ackTimeoutMs: false | number | undefined;
 
 		if (typeof methodOptions === 'object' && !Array.isArray(methodOptions)) {
@@ -243,7 +233,7 @@ export class SocketTransport<
 		}
 
 		if (typeof methodOptions === 'object' && (Array.isArray(methodOptions) || 'service' in methodOptions)) {
-			let serviceMethod: TServiceMethod | undefined;
+			let serviceMethod: string | undefined;
 
 			if (Array.isArray(methodOptions)) {
 				service = methodOptions[0];
@@ -260,7 +250,7 @@ export class SocketTransport<
 				cid: this._callIdGenerator(),
 				data: arg,
 				method: serviceMethod,
-				service
+				service: service
 			};
 		} else {
 			methodRequest = {
@@ -268,7 +258,7 @@ export class SocketTransport<
 				callback: null,
 				cid: this._callIdGenerator(),
 				data: arg,
-				method: ((typeof methodOptions === 'object') ? methodOptions.method : methodOptions) as TMethod
+				method: (typeof methodOptions === 'object') ? methodOptions.method : methodOptions
 			};
 		}
 
@@ -277,7 +267,7 @@ export class SocketTransport<
 		let abort: () => void;
 		const baseRequest = (serviceRequest || methodRequest!);
 
-		const promise = new Promise<FunctionReturnType<TOutgoing[TMethod] | TPrivateOutgoing[TPrivateMethod] | TService[TServiceName][TServiceMethod]>>((resolve, reject) => {
+		const promise = new Promise<unknown>((resolve, reject) => {
 			if (baseRequest.ackTimeoutMs) {
 				baseRequest.timeoutId = setTimeout(
 					() => {
@@ -305,7 +295,7 @@ export class SocketTransport<
 				}
 			};
 
-			baseRequest.callback = (err: Error | null, result?: TOutgoing[TMethod] | TPrivateOutgoing[TPrivateMethod] | TService[TServiceName][TServiceMethod]) => {
+			baseRequest.callback = (err: Error | null, result?: unknown) => {
 				delete callbackMap[baseRequest.cid];
 				baseRequest.callback = null;
 
@@ -319,7 +309,7 @@ export class SocketTransport<
 					return;
 				}
 
-				resolve(result as FunctionReturnType<TOutgoing[TMethod] | TPrivateOutgoing[TPrivateMethod] | TService[TServiceName][TServiceMethod]>);
+				resolve(result);
 			};
 
 			baseRequest.sentCallback = () => {
@@ -849,22 +839,12 @@ export class SocketTransport<
 		}
 	}
 
-	public transmit<TMethod extends keyof TOutgoing>(
-		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<void>;
-	public transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
-		options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<void>;
-	public transmit<TMethod extends keyof TPrivateOutgoing>(
-		method: TMethod, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]): Promise<void>;
-	public transmit<
-		TServiceName extends ServiceName<TService>,
-		TServiceMethod extends ServiceMethodName<TService, TServiceName>,
-		TMethod extends keyof TOutgoing
-	>(
-		serviceAndMethod: [TServiceName, TServiceMethod] | TMethod,
-		arg?: (Parameters<TOutgoing[TMethod] | TService[TServiceName][TServiceMethod]>)[0]
+	public transmit(
+		serviceAndMethod: [string, string] | string,
+		arg?: unknown
 	): Promise<void> {
-		let serviceRequest: Omit<TransmitServiceRequest<TService, TServiceName, TServiceMethod>, 'promise'> | undefined;
-		let methodRequest: Omit<TransmitMethodRequest<TOutgoing, TMethod>, 'promise'> | undefined;
+		let serviceRequest: Omit<TransmitServiceRequest<any, any, any>, 'promise'> | undefined;
+		let methodRequest: Omit<TransmitMethodRequest<any, any>, 'promise'> | undefined;
 
 		if (Array.isArray(serviceAndMethod)) {
 			serviceRequest = {
@@ -899,7 +879,7 @@ export class SocketTransport<
 
 		const request = Object.assign(baseRequest, { promise });
 
-		this.onTransmit(request);
+		this.onTransmit(request as AnyRequest<TOutgoing, TPrivateOutgoing, TService>);
 
 		return request.promise;
 	}

--- a/packages/core/src/socket.ts
+++ b/packages/core/src/socket.ts
@@ -6,7 +6,11 @@ import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux'
 import { HandlerMap } from './maps/handler-map.js';
 import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
 import { Plugin } from './plugins/plugin.js';
-import { AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, MessageEvent, PingEvent, PongEvent, RemoveAuthTokenEvent, RequestEvent, ResponseEvent, SocketEvent } from './socket-event.js';
+import {
+	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent,
+	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, MessageEvent, PingEvent,
+	PongEvent, RemoveAuthTokenEvent, RequestEvent, ResponseEvent, SocketEvent
+} from './socket-event.js';
 import { CallIdGenerator, InvokeMethodOptions, InvokeServiceOptions, SocketTransport } from './socket-transport.js';
 
 export interface SocketOptions<
@@ -45,7 +49,7 @@ export class Socket<
 	TPrivateOutgoing extends PrivateMethodMap,
 	TService extends ServiceMap,
 	TState extends object
-> extends AsyncStreamEmitter<SocketEvent<TIncoming, TOutgoing, TPrivateOutgoing, TService> | undefined> {
+> extends AsyncStreamEmitter<SocketEvent | undefined> {
 	private readonly _transport: SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>;
 	public readonly state: Partial<TState>;
 
@@ -87,9 +91,9 @@ export class Socket<
 	emit(event: 'ping', data: PingEvent): void;
 	emit(event: 'pong', data: PongEvent): void;
 	emit(event: 'removeAuthToken', data: RemoveAuthTokenEvent): void;
-	emit(event: 'request', data: RequestEvent<TIncoming, TService>): void;
-	emit(event: 'response', data: ResponseEvent<TOutgoing, TPrivateOutgoing, TService>): void;
-	emit(event: string, data?: SocketEvent<TIncoming, TOutgoing, TPrivateOutgoing, TService>): void {
+	emit(event: 'request', data: RequestEvent): void;
+	emit(event: 'response', data: ResponseEvent): void;
+	emit(event: string, data?: SocketEvent): void {
 		super.emit(event, data);
 	}
 
@@ -121,7 +125,7 @@ export class Socket<
 		return this._transport.invoke(methodOptions, arg)[0];
 	}
 
-	listen(): DemuxedConsumableStream<StreamEvent<SocketEvent<TIncoming, TOutgoing, TPrivateOutgoing, TService>>>;
+	listen(): DemuxedConsumableStream<StreamEvent<SocketEvent>>;
 	listen(event: 'authStateChange'): DemuxedConsumableStream<AuthStateChangeEvent>;
 	listen(event: 'authenticate'): DemuxedConsumableStream<AuthenticateEvent>;
 	listen(event: 'badAuthToken'): DemuxedConsumableStream<BadAuthTokenEvent>;
@@ -129,7 +133,7 @@ export class Socket<
 	listen(event: 'connect'): DemuxedConsumableStream<ConnectEvent>;
 	listen(event: 'connectAbort'): DemuxedConsumableStream<DisconnectEvent>;
 	listen(event: 'connecting'): DemuxedConsumableStream<ConnectingEvent>;
-	listen(event: 'deauthenticate'): DemuxedConsumableStream<AuthenticateEvent>;
+	listen(event: 'deauthenticate'): DemuxedConsumableStream<DeauthenticateEvent>;
 	listen(event: 'disconnect'): DemuxedConsumableStream<DisconnectEvent>;
 	listen(event: 'end'): DemuxedConsumableStream<void>;
 	listen(event: 'error'): DemuxedConsumableStream<ErrorEvent>;
@@ -137,10 +141,10 @@ export class Socket<
 	listen(event: 'ping'): DemuxedConsumableStream<PingEvent>;
 	listen(event: 'pong'): DemuxedConsumableStream<PongEvent>;
 	listen(event: 'removeAuthToken'): DemuxedConsumableStream<RemoveAuthTokenEvent>;
-	listen(event: 'request'): DemuxedConsumableStream<RequestEvent<TIncoming, TService>>;
-	listen(event: 'response'): DemuxedConsumableStream<ResponseEvent<TOutgoing, TPrivateOutgoing, TService>>;
-	listen<U extends SocketEvent<TIncoming, TOutgoing, TPrivateOutgoing, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
-	listen<U extends SocketEvent<TIncoming, TOutgoing, TPrivateOutgoing, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
+	listen(event: 'request'): DemuxedConsumableStream<RequestEvent>;
+	listen(event: 'response'): DemuxedConsumableStream<ResponseEvent>;
+	listen<U extends SocketEvent, V = U>(event: string): DemuxedConsumableStream<V>;
+	listen<U extends SocketEvent, V = U>(event?: string): DemuxedConsumableStream<V> {
 		return super.listen(event ?? '');
 	}
 

--- a/packages/core/src/socket.ts
+++ b/packages/core/src/socket.ts
@@ -4,7 +4,7 @@ import { CodecEngine } from '@socket-mesh/formatter';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
 
 import { HandlerMap } from './maps/handler-map.js';
-import { FunctionReturnType, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName } from './maps/method-map.js';
+import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
 import { Plugin } from './plugins/plugin.js';
 import { AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, MessageEvent, PingEvent, PongEvent, RemoveAuthTokenEvent, RequestEvent, ResponseEvent, SocketEvent } from './socket-event.js';
 import { CallIdGenerator, InvokeMethodOptions, InvokeServiceOptions, SocketTransport } from './socket-transport.js';
@@ -114,18 +114,11 @@ export class Socket<
 		return this._transport.id;
 	}
 
-	public invoke<TMethod extends keyof TOutgoing>(
-		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
-	public invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
-		options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
-	public invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
-		options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
-	public invoke<TMethod extends keyof TOutgoing>(
-		options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
-	public invoke<TServiceName extends ServiceName<TService>, TServiceMethod extends ServiceMethodName<TService, TServiceName>, TMethod extends keyof TOutgoing>(
-		methodOptions: [TServiceName, TServiceMethod, (false | number)?] | InvokeMethodOptions<TOutgoing, TMethod> | InvokeServiceOptions<TService, TServiceName, TServiceMethod> | TMethod,
-		arg?: Parameters<TOutgoing[TMethod] | TService[TServiceName][TServiceMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod] | TService[TServiceName][TServiceMethod]>> {
-		return this._transport.invoke(methodOptions as TMethod, arg)[0];
+	public invoke(
+		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
+		arg?: unknown
+	): Promise<unknown> {
+		return this._transport.invoke(methodOptions, arg)[0];
 	}
 
 	listen(): DemuxedConsumableStream<StreamEvent<SocketEvent<TIncoming, TOutgoing, TPrivateOutgoing, TService>>>;
@@ -159,14 +152,11 @@ export class Socket<
 		return this._transport.status;
 	}
 
-	public transmit<TMethod extends keyof TOutgoing>(
-		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<void>;
-	public transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
-		options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<void>;
-	public transmit<TServiceName extends ServiceName<TService>, TServiceMethod extends ServiceMethodName<TService, TServiceName>, TMethod extends keyof TOutgoing>(
-		serviceAndMethod: [TServiceName, TServiceMethod] | TMethod,
-		arg?: (Parameters<TOutgoing[TMethod] | TService[TServiceName][TServiceMethod]>)[0]): Promise<void> {
-		return this._transport.transmit(serviceAndMethod as TMethod, arg);
+	public transmit(
+		serviceAndMethod: [string, string] | string,
+		arg?: unknown
+	): Promise<void> {
+		return this._transport.transmit(serviceAndMethod, arg);
 	}
 
 	public get url(): string {

--- a/packages/core/src/socket.ts
+++ b/packages/core/src/socket.ts
@@ -3,29 +3,28 @@ import { AuthToken, SignedAuthToken } from '@socket-mesh/auth';
 import { CodecEngine } from '@socket-mesh/formatter';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
 
-import { HandlerMap } from './maps/handler-map.js';
-import { MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap } from './maps/method-map.js';
-import { Plugin } from './plugins/plugin.js';
+import {
+	FunctionReturnType, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName
+} from './maps/method-map.js';
+import { AnyPlugin } from './plugins/plugin.js';
+import { LooseHandlerMap } from './request-handler.js';
 import {
 	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent,
 	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, MessageEvent, PingEvent,
-	PongEvent, RemoveAuthTokenEvent, RequestEvent, ResponseEvent, SocketEvent
+	PongEvent, RemoveAuthTokenEvent, RequestEvent, ResponseEvent, SocketEvent, TypedRequestEvent,
+	TypedResponseEvent
 } from './socket-event.js';
-import { CallIdGenerator, InvokeMethodOptions, InvokeServiceOptions, SocketTransport } from './socket-transport.js';
+import {
+	BaseSocketTransport, CallIdGenerator, InvokeMethodOptions, InvokeServiceOptions
+} from './socket-transport.js';
 
-export interface SocketOptions<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> {
+export interface BaseSocketOptions<TState extends object = {}> {
 	ackTimeoutMs?: number,
 	callIdGenerator?: CallIdGenerator,
 	codecEngine?: CodecEngine,
-	handlers?: HandlerMap<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
+	handlers?: LooseHandlerMap,
 	isPingTimeoutDisabled?: boolean,
-	plugins?: Plugin<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>[],
+	plugins?: AnyPlugin[],
 	state?: Partial<TState>,
 
 	// Lets you specify the default cleanup behaviour for
@@ -39,23 +38,55 @@ export interface SocketOptions<
 	streamCleanupMode?: StreamCleanupMode
 }
 
+export type Socket<
+	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
+	TService extends ServiceMap = {},
+	TPrivateIncoming extends PrivateMethodMap = {},
+	TPrivateOutgoing extends PrivateMethodMap = {}
+> = Omit<BaseSocket<TState>, 'invoke' | 'listen' | 'transmit'> & {
+	invoke<TMethod extends keyof TOutgoing & string>(
+		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]
+	): Promise<FunctionReturnType<TOutgoing[TMethod]>>,
+	invoke<TMethod extends keyof TOutgoing & string>(
+		options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]
+	): Promise<FunctionReturnType<TOutgoing[TMethod]>>,
+	invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
+		options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]
+	): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>,
+	invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
+		options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]
+	): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>,
+	invoke<TMethod extends keyof TPrivateOutgoing & string>(
+		method: TMethod, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]
+	): Promise<FunctionReturnType<TPrivateOutgoing[TMethod]>>,
+
+	listen(event: 'request'): DemuxedConsumableStream<TypedRequestEvent<TIncoming & TPrivateIncoming, TService>>,
+	listen(event: 'response'): DemuxedConsumableStream<TypedResponseEvent<TOutgoing, TPrivateOutgoing, TService>>,
+
+	transmit<TMethod extends keyof TOutgoing & string>(
+		method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]
+	): Promise<void>,
+	transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(
+		options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]
+	): Promise<void>,
+	transmit<TMethod extends keyof TPrivateOutgoing & string>(
+		method: TMethod, arg?: Parameters<TPrivateOutgoing[TMethod]>[0]
+	): Promise<void>
+};
+
 export type SocketStatus = 'closed' | 'closing' | 'connecting' | 'ready';
 
 export type StreamCleanupMode = 'close' | 'kill' | 'none';
 
-export class Socket<
-	TIncoming extends MethodMap,
-	TOutgoing extends PublicMethodMap,
-	TPrivateOutgoing extends PrivateMethodMap,
-	TService extends ServiceMap,
-	TState extends object
-> extends AsyncStreamEmitter<SocketEvent | undefined> {
-	private readonly _transport: SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>;
+export class BaseSocket<TState extends object = {}> extends AsyncStreamEmitter<SocketEvent | undefined> {
+	private readonly _transport: BaseSocketTransport<TState>;
 	public readonly state: Partial<TState>;
 
 	protected constructor(
-		transport: SocketTransport<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>,
-		options?: SocketOptions<TIncoming, TOutgoing, TPrivateOutgoing, TService, TState>
+		transport: BaseSocketTransport<TState>,
+		options?: BaseSocketOptions<TState>
 	) {
 		super();
 

--- a/packages/formatter/test/index.spec.ts
+++ b/packages/formatter/test/index.spec.ts
@@ -1,4 +1,3 @@
-import { toError } from '@socket-mesh/core';
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
@@ -82,7 +81,7 @@ describe('formatter', function () {
 			try {
 				codec.encode(rawObject);
 			} catch (err) {
-				error = toError(err);
+				error = err instanceof Error ? err : new Error(String(err));
 			}
 
 			assert(error != null, 'Expected an error to be thrown');

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@socket-mesh/server",
 	"description": "A TCP socket pair for easily transmitting full messages without worrying about request size limits.",
-	"version": "18.1.5",
+	"version": "19.0.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/server/src/events/index.ts
+++ b/packages/server/src/events/index.ts
@@ -1,9 +1,9 @@
 import { ChannelMap, SubscribeEvent, SubscribeFailEvent, SubscribeStateChangeEvent, UnsubscribeEvent } from '@socket-mesh/channels';
-import { ClientSocket, ServerPrivateMap } from '@socket-mesh/client';
+import { ClientPrivateMap, ClientSocket, ServerPrivateMap } from '@socket-mesh/client';
 import {
 	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent,
-	DisconnectEvent, MessageEvent, PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent,
-	ResponseEvent,
+	DisconnectEvent, MessageEvent, PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap,
+	RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
 	CloseEvent as SCloseEvent,
 	ErrorEvent as SErrorEvent,
 	ServiceMap
@@ -258,7 +258,7 @@ export type SocketResponseEvent<
 	TPrivateOutgoing extends PrivateMethodMap,
 	TServerState extends object,
 	TState extends object
-> = ResponseEvent<TOutgoing, TPrivateOutgoing, TService>
+> = ResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>
 	& ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
 
 export type SocketSubscribeEvent<

--- a/packages/server/src/events/index.ts
+++ b/packages/server/src/events/index.ts
@@ -15,16 +15,16 @@ import { ServerSocket } from '../server-socket.js';
 export interface CloseEvent {}
 
 export interface ConnectionEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > {
-	socket: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
+	socket: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
 	upgradeReq: IncomingMessage
 }
 
@@ -33,16 +33,16 @@ export interface ErrorEvent {
 }
 
 export interface HandshakeEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > {
-	socket: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	socket: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 }
 
 export interface HeadersEvent {
@@ -53,257 +53,257 @@ export interface HeadersEvent {
 export interface ListeningEvent {}
 
 export type ServerEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > =
 	CloseEvent
-	| ConnectionEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	| ConnectionEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	| ErrorEvent
-	| HandshakeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	| HandshakeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	| HeadersEvent
 	| ListeningEvent
-	| SocketAuthenticateEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketAuthStateChangeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketBadAuthTokenEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketCloseEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketConnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketConnectingEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketDeauthenticateEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketDisconnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketErrorEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketMessageEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketPingEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketPongEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketRemoveAuthTokenEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	| SocketRequestEvent<TService, TIncoming, TPrivateIncoming>
-	| SocketResponseEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	| SocketAuthenticateEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketAuthStateChangeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketBadAuthTokenEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketCloseEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketConnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketConnectingEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketDeauthenticateEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketDisconnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketErrorEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketMessageEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketPingEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketPongEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketRemoveAuthTokenEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+	| SocketRequestEvent<TIncoming, TService, TPrivateIncoming>
+	| SocketResponseEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	| WarningEvent;
 
 export interface ServerSocketEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > {
 	socket:
-		ClientSocket<PublicMethodMap, TChannel, TService, TState, TOutgoing & TPrivateOutgoing, TPrivateIncoming>
-		| ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+		ClientSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateOutgoing>
+		| ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 }
 
 export type SocketAuthenticateEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = AuthenticateEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = AuthenticateEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketAuthStateChangeEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = AuthStateChangeEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = AuthStateChangeEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketBadAuthTokenEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = BadAuthTokenEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = BadAuthTokenEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketCloseEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = SCloseEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = SCloseEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketConnectEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = ConnectEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = ConnectEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketConnectingEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = ConnectingEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = ConnectingEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketDeauthenticateEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = DeauthenticateEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = DeauthenticateEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketDisconnectEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = DisconnectEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = DisconnectEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketErrorEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = SErrorEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = SErrorEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketMessageEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = MessageEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = MessageEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketPingEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = PingEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = PingEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketPongEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = PongEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = PongEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketRemoveAuthTokenEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = RemoveAuthTokenEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = RemoveAuthTokenEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketRequestEvent<
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
+	TService extends ServiceMap,
 	TPrivateIncoming extends PrivateMethodMap
 > = TypedRequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>;
 
 export type SocketResponseEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > = TypedResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>
-	& ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	& ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketSubscribeEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = SubscribeEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = SubscribeEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketSubscribeFailEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = SubscribeFailEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = SubscribeFailEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketSubscribeStateChangeEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = SubscribeStateChangeEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = SubscribeStateChangeEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export type SocketUnsubscribeEvent<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
-> = UnsubscribeEvent & ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object
+> = UnsubscribeEvent & ServerSocketEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
 export interface WarningEvent {
 	warning: Error

--- a/packages/server/src/events/index.ts
+++ b/packages/server/src/events/index.ts
@@ -3,10 +3,10 @@ import { ClientPrivateMap, ClientSocket, ServerPrivateMap } from '@socket-mesh/c
 import {
 	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent,
 	DisconnectEvent, MessageEvent, PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap,
-	RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
+	RemoveAuthTokenEvent,
 	CloseEvent as SCloseEvent,
 	ErrorEvent as SErrorEvent,
-	ServiceMap
+	ServiceMap, TypedRequestEvent, TypedResponseEvent
 } from '@socket-mesh/core';
 import { IncomingMessage } from 'http';
 
@@ -247,7 +247,7 @@ export type SocketRequestEvent<
 	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TPrivateIncoming extends PrivateMethodMap
-> = RequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>;
+> = TypedRequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>;
 
 export type SocketResponseEvent<
 	TChannel extends ChannelMap,
@@ -258,7 +258,7 @@ export type SocketResponseEvent<
 	TPrivateOutgoing extends PrivateMethodMap,
 	TServerState extends object,
 	TState extends object
-> = ResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>
+> = TypedResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>
 	& ServerSocketEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
 
 export type SocketSubscribeEvent<

--- a/packages/server/src/handlers/publish.ts
+++ b/packages/server/src/handlers/publish.ts
@@ -4,7 +4,7 @@ import { InvalidActionError } from '@socket-mesh/errors';
 import { ServerRequestHandlerArgs } from './server-request-handler.js';
 
 export async function publishHandler(
-	{ options, socket, transport }: ServerRequestHandlerArgs<PublishOptions, {}, { [channel: string]: any }>
+	{ options, socket, transport }: ServerRequestHandlerArgs<PublishOptions, {}, {}, { [channel: string]: any }>
 ): Promise<void> {
 	if (!socket.server.allowClientPublish) {
 		throw new InvalidActionError('Client publish feature is disabled');

--- a/packages/server/src/handlers/remove-auth-token.ts
+++ b/packages/server/src/handlers/remove-auth-token.ts
@@ -1,10 +1,10 @@
-import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
+import { ClientPrivateMap } from '@socket-mesh/client';
 import { SocketTransport } from '@socket-mesh/core';
 
 import { ServerSocketState } from '../server-socket-state.js';
 
 export async function deauthenticate(
-	transport: SocketTransport<ServerPrivateMap, {}, ClientPrivateMap, {}, ServerSocketState>
+	transport: SocketTransport<{}, {}, ServerSocketState, {}, {}, ClientPrivateMap>
 ): Promise<boolean> {
 	if (await transport.changeToUnauthenticatedState()) {
 		await transport.transmit('#removeAuthToken');

--- a/packages/server/src/handlers/server-request-handler.ts
+++ b/packages/server/src/handlers/server-request-handler.ts
@@ -1,5 +1,4 @@
 import { ChannelMap } from '@socket-mesh/channels';
-import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
 import { PrivateMethodMap, PublicMethodMap, RequestHandlerArgs, ServiceMap } from '@socket-mesh/core';
 
 import { ServerSocketState } from '../server-socket-state.js';
@@ -8,21 +7,17 @@ import { ServerTransport } from '../server-transport.js';
 
 export type ServerRequestHandlerArgs<
 	TOptions,
-	TIncoming extends PublicMethodMap = {},
-	TChannel extends ChannelMap = {},
-	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
-	TPrivateIncoming extends PrivateMethodMap = {},
-	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TIncoming extends PublicMethodMap = any,
+	TChannel extends ChannelMap = any,
+	TService extends ServiceMap = any,
+	TOutgoing extends PublicMethodMap = any,
+	TPrivateIncoming extends PrivateMethodMap = any,
+	TPrivateOutgoing extends PrivateMethodMap = any,
+	TServerState extends object = any,
+	TState extends object = any
 > =
 	RequestHandlerArgs<
 		TOptions,
-		TIncoming & TPrivateIncoming & ServerPrivateMap,
-		TOutgoing,
-		TPrivateOutgoing & ClientPrivateMap,
-		TService,
 		TState & ServerSocketState,
 		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
 		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>

--- a/packages/server/src/handlers/server-request-handler.ts
+++ b/packages/server/src/handlers/server-request-handler.ts
@@ -8,17 +8,17 @@ import { ServerTransport } from '../server-transport.js';
 export type ServerRequestHandlerArgs<
 	TOptions,
 	TIncoming extends PublicMethodMap = any,
+	TOutgoing extends PublicMethodMap = any,
 	TChannel extends ChannelMap = any,
 	TService extends ServiceMap = any,
-	TOutgoing extends PublicMethodMap = any,
+	TState extends object = any,
 	TPrivateIncoming extends PrivateMethodMap = any,
 	TPrivateOutgoing extends PrivateMethodMap = any,
-	TServerState extends object = any,
-	TState extends object = any
+	TServerState extends object = any
 > =
 	RequestHandlerArgs<
 		TOptions,
 		TState & ServerSocketState,
-		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+		ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+		ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	>;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,18 +20,18 @@ export type { PluginType } from '@socket-mesh/core';
  * @api public
  */
 export function attach<
-	TChannel extends ChannelMap = {},
-	TService extends ServiceMap = {},
 	TIncoming extends PublicMethodMap = {},
 	TOutgoing extends PublicMethodMap = {},
+	TChannel extends ChannelMap = {},
+	TService extends ServiceMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TServerState extends object = {}
 >(
 	server: http.Server,
-	options?: ServerOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-): Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState> {
+	options?: ServerOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+): Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState> {
 	if (options == null) {
 		options = {};
 	}
@@ -50,53 +50,53 @@ export function attach<
  */
 export function listen<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
->(): Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	TServerState extends object = {}
+>(): Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 export function listen<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TServerState extends object = {}
 >(
 	port: number,
-	options: ServerOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-): Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	options: ServerOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+): Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 export function listen<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TServerState extends object = {}
 >(
 	port: number,
-	options: ServerOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>, fn: () => void
-): Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	options: ServerOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>, fn: () => void
+): Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 export function listen<
 	TIncoming extends PublicMethodMap,
+	TOutgoing extends PublicMethodMap,
 	TChannel extends ChannelMap,
 	TService extends ServiceMap,
-	TOutgoing extends PublicMethodMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 >(
 	port?: number,
-	options?: (() => void) | ServerOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>, fn?: () => void
-): Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState> {
+	options?: (() => void) | ServerOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>, fn?: () => void
+): Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState> {
 	if (typeof options === 'function') {
 		fn = options;
 		options = {};

--- a/packages/server/src/plugin/server-plugin.ts
+++ b/packages/server/src/plugin/server-plugin.ts
@@ -1,10 +1,8 @@
 import { ChannelMap, ChannelOptions } from '@socket-mesh/channels';
-import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
 import { Plugin, PrivateMethodMap, PublicMethodMap, ServiceMap } from '@socket-mesh/core';
 import { IncomingMessage } from 'http';
 
 import { AuthInfo } from '../handlers/authenticate.js';
-import { ServerSocketState } from '../server-socket-state.js';
 import { ServerSocket } from '../server-socket.js';
 import { ServerTransport } from '../server-transport.js';
 
@@ -49,11 +47,8 @@ export interface ServerPlugin<
 	TServerState extends object,
 	TState extends object
 > extends Plugin<
-	TIncoming & TPrivateIncoming & ServerPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ClientPrivateMap,
-	TService,
-	TState & ServerSocketState
+		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
+		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
 	> {
 	onAuthenticate?: (authInfo: AuthInfo) => void,
 	onConnection?: (request: IncomingMessage) => Promise<void>,

--- a/packages/server/src/plugin/server-plugin.ts
+++ b/packages/server/src/plugin/server-plugin.ts
@@ -7,69 +7,69 @@ import { ServerSocket } from '../server-socket.js';
 import { ServerTransport } from '../server-transport.js';
 
 export interface HandshakePluginArgs<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > {
 	authInfo: AuthInfo,
-	socket: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-	transport: ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	socket: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+	transport: ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 }
 
 export interface PublishPluginArgs<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > {
 	channel: string,
 	data: any,
-	socket: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-	transport: ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	socket: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+	transport: ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 }
 
 export interface ServerPlugin<
 	TIncoming extends PublicMethodMap,
+	TOutgoing extends PublicMethodMap,
 	TChannel extends ChannelMap,
 	TService extends ServiceMap,
-	TOutgoing extends PublicMethodMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > extends Plugin<
-		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+		ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+		ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	> {
 	onAuthenticate?: (authInfo: AuthInfo) => void,
 	onConnection?: (request: IncomingMessage) => Promise<void>,
-	onHandshake?: (options: HandshakePluginArgs<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) => Promise<void>,
-	onPublishIn?: (options: PublishPluginArgs<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) => Promise<any>,
-	onPublishOut?: (options: PublishPluginArgs<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) => Promise<any>,
-	onSubscribe?: (options: SubscribePluginArgs<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) => Promise<void>
+	onHandshake?: (options: HandshakePluginArgs<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) => Promise<void>,
+	onPublishIn?: (options: PublishPluginArgs<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) => Promise<any>,
+	onPublishOut?: (options: PublishPluginArgs<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) => Promise<any>,
+	onSubscribe?: (options: SubscribePluginArgs<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) => Promise<void>
 }
 
 export interface SubscribePluginArgs<
-	TChannel extends ChannelMap,
-	TService extends ServiceMap,
 	TIncoming extends PublicMethodMap,
 	TOutgoing extends PublicMethodMap,
+	TChannel extends ChannelMap,
+	TService extends ServiceMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > {
 	channel: string,
 	options: ChannelOptions,
-	socket: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-	transport: ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	socket: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+	transport: ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 };

--- a/packages/server/src/server-options.ts
+++ b/packages/server/src/server-options.ts
@@ -1,12 +1,15 @@
 import { AuthEngine, AuthOptions } from '@socket-mesh/auth-engine';
 import { ChannelMap } from '@socket-mesh/channels';
-import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
+import { ServerPrivateMap } from '@socket-mesh/client';
 import { CallIdGenerator, HandlerMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode } from '@socket-mesh/core';
 import { CodecEngine } from '@socket-mesh/formatter';
 import { ServerOptions as WebSocketServerOptions } from 'ws';
 
 import { Broker } from './broker/broker.js';
 import { ServerPlugin } from './plugin/server-plugin.js';
+import { ServerSocketState } from './server-socket-state.js';
+import { ServerSocket } from './server-socket.js';
+import { ServerTransport } from './server-transport.js';
 
 export interface ServerOptions<
 	TIncoming extends PublicMethodMap = {},
@@ -33,7 +36,12 @@ export interface ServerOptions<
 
 	codecEngine?: CodecEngine,
 
-	handlers?: HandlerMap<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService, TState>,
+	handlers?: HandlerMap<
+		TIncoming & TPrivateIncoming & ServerPrivateMap,
+		TState & ServerSocketState,
+		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
+		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+	>,
 
 	// In milliseconds, the timeout for receiving a response
 	// when using invoke() or invokePublish(). ackTimeout: number

--- a/packages/server/src/server-options.ts
+++ b/packages/server/src/server-options.ts
@@ -13,13 +13,13 @@ import { ServerTransport } from './server-transport.js';
 
 export interface ServerOptions<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TServerState extends object = {}
 > extends WebSocketServerOptions {
 	// In milliseconds, the timeout for receiving a response
 	// when using invoke() or invokePublish().
@@ -39,8 +39,8 @@ export interface ServerOptions<
 	handlers?: HandlerMap<
 		TIncoming & TPrivateIncoming & ServerPrivateMap,
 		TState & ServerSocketState,
-		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+		ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+		ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	>,
 
 	// In milliseconds, the timeout for receiving a response
@@ -58,7 +58,7 @@ export interface ServerOptions<
 
 	pingTimeoutMs?: number,
 
-	plugins?: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[],
+	plugins?: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[],
 
 	// The maximum number of unique channels which a single socket can subscribe to.
 	socketChannelLimit?: number,

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -3,9 +3,9 @@ import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
 import {
 	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, BaseSocket, BaseSocketOptions,
 	CloseEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent,
-	FunctionReturnType, HandlerMap, InvokeMethodOptions, InvokeServiceOptions, MessageEvent,
+	FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, LooseHandlerMap, MessageEvent,
 	PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent,
-	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, SocketEvent, toError,
+	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError,
 	TypedRequestEvent, TypedResponseEvent, TypedSocketEvent
 } from '@socket-mesh/core';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
@@ -28,12 +28,7 @@ export interface ServerSocketOptions<
 	TServerState extends object,
 	TState extends object
 > extends BaseSocketOptions<TState & ServerSocketState> {
-	handlers: HandlerMap<
-		TIncoming & TPrivateIncoming & ServerPrivateMap,
-		TState & ServerSocketState,
-		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	>,
+	handlers: LooseHandlerMap,
 	id?: string,
 	plugins?: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[],
 	request: IncomingMessage,
@@ -51,7 +46,15 @@ export class ServerSocket<
 	TPrivateOutgoing extends PrivateMethodMap = {},
 	TServerState extends object = {},
 	TState extends object = {}
-> extends BaseSocket<TState & ServerSocketState> {
+> extends BaseSocket<TState & ServerSocketState>
+	implements Socket<
+		TIncoming & TPrivateIncoming & ServerPrivateMap,
+		TOutgoing,
+		TState & ServerSocketState,
+		TService,
+		{},
+		TPrivateOutgoing & ClientPrivateMap
+	> {
 	private _serverTransport: ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
 	public readonly server: Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
 

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -1,11 +1,11 @@
 import { ChannelMap } from '@socket-mesh/channels';
 import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
 import {
-	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent,
-	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, FunctionReturnType,
-	HandlerMap, InvokeMethodOptions, InvokeServiceOptions, MessageEvent, PingEvent, PongEvent,
-	PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
-	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, SocketOptions, toError,
+	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, BaseSocket, BaseSocketOptions,
+	CloseEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent,
+	FunctionReturnType, HandlerMap, InvokeMethodOptions, InvokeServiceOptions, MessageEvent,
+	PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent,
+	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, SocketEvent, toError,
 	TypedRequestEvent, TypedResponseEvent, TypedSocketEvent
 } from '@socket-mesh/core';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
@@ -27,19 +27,12 @@ export interface ServerSocketOptions<
 	TPrivateOutgoing extends PrivateMethodMap,
 	TServerState extends object,
 	TState extends object
-> extends SocketOptions<
-	TIncoming & TPrivateIncoming & ServerPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ClientPrivateMap,
-	TService,
-	TState & ServerSocketState
-	> {
+> extends BaseSocketOptions<TState & ServerSocketState> {
 	handlers: HandlerMap<
 		TIncoming & TPrivateIncoming & ServerPrivateMap,
-		TOutgoing,
-		TPrivateOutgoing & ClientPrivateMap,
-		TService,
-		TState & ServerSocketState
+		TState & ServerSocketState,
+		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
+		ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
 	>,
 	id?: string,
 	plugins?: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[],
@@ -58,13 +51,7 @@ export class ServerSocket<
 	TPrivateOutgoing extends PrivateMethodMap = {},
 	TServerState extends object = {},
 	TState extends object = {}
-> extends Socket<
-	TIncoming & TPrivateIncoming & ServerPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ClientPrivateMap,
-	TService,
-	TState & ServerSocketState
-	> {
+> extends BaseSocket<TState & ServerSocketState> {
 	private _serverTransport: ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
 	public readonly server: Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
 

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -1,6 +1,6 @@
 import { ChannelMap } from '@socket-mesh/channels';
 import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
-import { HandlerMap, PrivateMethodMap, PublicMethodMap, ServiceMap, Socket, SocketOptions, toError } from '@socket-mesh/core';
+import { FunctionReturnType, HandlerMap, InvokeMethodOptions, InvokeServiceOptions, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName, Socket, SocketOptions, toError } from '@socket-mesh/core';
 import { IncomingMessage } from 'http';
 import { WebSocket } from 'ws';
 
@@ -103,6 +103,19 @@ export class ServerSocket<
 		return this._serverTransport.id;
 	}
 
+	override invoke<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
+	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
+	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<FunctionReturnType<TService[TServiceName][TMethod]>>;
+	override invoke<TMethod extends keyof TOutgoing & string>(options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<FunctionReturnType<TOutgoing[TMethod]>>;
+	override invoke<TMethod extends keyof (TPrivateOutgoing & ClientPrivateMap) & string>(method: TMethod, arg: Parameters<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>[0]): Promise<FunctionReturnType<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>>;
+	override invoke<TMethod extends keyof (TPrivateOutgoing & ClientPrivateMap) & string>(options: InvokeMethodOptions<(TPrivateOutgoing & ClientPrivateMap), TMethod>, arg?: Parameters<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>[0]): Promise<FunctionReturnType<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>>;
+	override invoke(
+		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
+		arg?: unknown
+	): Promise<unknown> {
+		return super.invoke(methodOptions, arg);
+	}
+
 	kickOut(channel: string, message: string): Promise<void[]> {
 		const channels = channel ? [channel] : Object.keys(this.state.channelSubscriptions || {});
 
@@ -118,6 +131,16 @@ export class ServerSocket<
 
 	get service(): string | undefined {
 		return this._serverTransport.service;
+	}
+
+	override transmit<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<void>;
+	override transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<void>;
+	override transmit<TMethod extends keyof (TPrivateOutgoing & ClientPrivateMap) & string>(method: TMethod, arg?: Parameters<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>[0]): Promise<void>;
+	override transmit(
+		serviceAndMethod: [string, string] | string,
+		arg?: unknown
+	): Promise<void> {
+		return super.transmit(serviceAndMethod, arg);
 	}
 
 	get type(): 'server' {

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -20,32 +20,32 @@ import { Server } from './server.js';
 
 export interface ServerSocketOptions<
 	TIncoming extends PublicMethodMap,
+	TOutgoing extends PublicMethodMap,
 	TChannel extends ChannelMap,
 	TService extends ServiceMap,
-	TOutgoing extends PublicMethodMap,
+	TState extends object,
 	TPrivateIncoming extends PrivateMethodMap,
 	TPrivateOutgoing extends PrivateMethodMap,
-	TServerState extends object,
-	TState extends object
+	TServerState extends object
 > extends BaseSocketOptions<TState & ServerSocketState> {
 	handlers: LooseHandlerMap,
 	id?: string,
-	plugins?: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[],
+	plugins?: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[],
 	request: IncomingMessage,
-	server: Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
+	server: Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
 	service?: string,
 	socket: WebSocket
 }
 
 export class ServerSocket<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TServerState extends object = {}
 > extends BaseSocket<TState & ServerSocketState>
 	implements Socket<
 		TIncoming & TPrivateIncoming & ServerPrivateMap,
@@ -55,11 +55,11 @@ export class ServerSocket<
 		{},
 		TPrivateOutgoing & ClientPrivateMap
 	> {
-	private _serverTransport: ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
-	public readonly server: Server<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	private _serverTransport: ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
+	public readonly server: Server<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 
-	constructor(options: ServerSocketOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) {
-		const transport = new ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>(options);
+	constructor(options: ServerSocketOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) {
+		const transport = new ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>(options);
 
 		super(transport, options);
 

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -5,7 +5,8 @@ import {
 	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, FunctionReturnType,
 	HandlerMap, InvokeMethodOptions, InvokeServiceOptions, MessageEvent, PingEvent, PongEvent,
 	PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
-	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, SocketOptions, toError
+	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, SocketOptions, toError,
+	TypedRequestEvent, TypedResponseEvent, TypedSocketEvent
 } from '@socket-mesh/core';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
 import { IncomingMessage } from 'http';
@@ -102,8 +103,8 @@ export class ServerSocket<
 		return result;
 	}
 
-	override emit(event: 'request', data: RequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>): void;
-	override emit(event: 'response', data: ResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>): void;
+	override emit(event: 'request', data: TypedRequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>): void;
+	override emit(event: 'response', data: TypedResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>): void;
 	override emit(event: 'authStateChange', data: AuthStateChangeEvent): void;
 	override emit(event: 'authenticate', data: AuthenticateEvent): void;
 	override emit(event: 'badAuthToken', data: BadAuthTokenEvent): void;
@@ -155,7 +156,7 @@ export class ServerSocket<
 		}));
 	}
 
-	override listen(): DemuxedConsumableStream<StreamEvent<SocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>>>;
+	override listen(): DemuxedConsumableStream<StreamEvent<TypedSocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>>>;
 	override listen(event: 'authStateChange'): DemuxedConsumableStream<AuthStateChangeEvent>;
 	override listen(event: 'authenticate'): DemuxedConsumableStream<AuthenticateEvent>;
 	override listen(event: 'badAuthToken'): DemuxedConsumableStream<BadAuthTokenEvent>;
@@ -171,10 +172,10 @@ export class ServerSocket<
 	override listen(event: 'ping'): DemuxedConsumableStream<PingEvent>;
 	override listen(event: 'pong'): DemuxedConsumableStream<PongEvent>;
 	override listen(event: 'removeAuthToken'): DemuxedConsumableStream<RemoveAuthTokenEvent>;
-	override listen(event: 'request'): DemuxedConsumableStream<RequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>>;
-	override listen(event: 'response'): DemuxedConsumableStream<ResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>>;
-	override listen<U extends SocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
-	override listen<U extends SocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
+	override listen(event: 'request'): DemuxedConsumableStream<TypedRequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>>;
+	override listen(event: 'response'): DemuxedConsumableStream<TypedResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>>;
+	override listen<U extends TypedSocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
+	override listen<U extends TypedSocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
 		return super.listen<U, V>(event ?? '');
 	}
 

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -1,6 +1,13 @@
 import { ChannelMap } from '@socket-mesh/channels';
 import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
-import { FunctionReturnType, HandlerMap, InvokeMethodOptions, InvokeServiceOptions, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName, Socket, SocketOptions, toError } from '@socket-mesh/core';
+import {
+	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, CloseEvent, ConnectEvent,
+	ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent, FunctionReturnType,
+	HandlerMap, InvokeMethodOptions, InvokeServiceOptions, MessageEvent, PingEvent, PongEvent,
+	PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent, ResponseEvent,
+	ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, SocketOptions, toError
+} from '@socket-mesh/core';
+import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
 import { IncomingMessage } from 'http';
 import { WebSocket } from 'ws';
 
@@ -95,6 +102,29 @@ export class ServerSocket<
 		return result;
 	}
 
+	override emit(event: 'request', data: RequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>): void;
+	override emit(event: 'response', data: ResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>): void;
+	override emit(event: 'authStateChange', data: AuthStateChangeEvent): void;
+	override emit(event: 'authenticate', data: AuthenticateEvent): void;
+	override emit(event: 'badAuthToken', data: BadAuthTokenEvent): void;
+	override emit(event: 'close', data: CloseEvent): void;
+	override emit(event: 'connect', data: ConnectEvent): void;
+	override emit(event: 'connectAbort', data: DisconnectEvent): void;
+	override emit(event: 'connecting', data: ConnectingEvent): void;
+	override emit(event: 'deauthenticate', data: DeauthenticateEvent): void;
+	override emit(event: 'disconnect', data: DisconnectEvent): void;
+	override emit(event: 'end'): void;
+	override emit(event: 'error', data: ErrorEvent): void;
+	override emit(event: 'message', data: MessageEvent): void;
+	override emit(event: 'ping', data: PingEvent): void;
+	override emit(event: 'pong', data: PongEvent): void;
+	override emit(event: 'removeAuthToken', data: RemoveAuthTokenEvent): void;
+	override emit(event: 'request', data: RequestEvent): void;
+	override emit(event: 'response', data: ResponseEvent): void;
+	override emit(event: string, data?: SocketEvent): void {
+		(super.emit as (event: string, data?: SocketEvent) => void)(event, data);
+	}
+
 	public get exchange(): Exchange<TChannel> {
 		return this.server.exchange;
 	}
@@ -123,6 +153,29 @@ export class ServerSocket<
 			this.transmit('#kickOut', { channel: channelName, message });
 			return this._serverTransport.unsubscribe(channelName);
 		}));
+	}
+
+	override listen(): DemuxedConsumableStream<StreamEvent<SocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>>>;
+	override listen(event: 'authStateChange'): DemuxedConsumableStream<AuthStateChangeEvent>;
+	override listen(event: 'authenticate'): DemuxedConsumableStream<AuthenticateEvent>;
+	override listen(event: 'badAuthToken'): DemuxedConsumableStream<BadAuthTokenEvent>;
+	override listen(event: 'close'): DemuxedConsumableStream<CloseEvent>;
+	override listen(event: 'connect'): DemuxedConsumableStream<ConnectEvent>;
+	override listen(event: 'connectAbort'): DemuxedConsumableStream<DisconnectEvent>;
+	override listen(event: 'connecting'): DemuxedConsumableStream<ConnectingEvent>;
+	override listen(event: 'deauthenticate'): DemuxedConsumableStream<DeauthenticateEvent>;
+	override listen(event: 'disconnect'): DemuxedConsumableStream<DisconnectEvent>;
+	override listen(event: 'end'): DemuxedConsumableStream<void>;
+	override listen(event: 'error'): DemuxedConsumableStream<ErrorEvent>;
+	override listen(event: 'message'): DemuxedConsumableStream<MessageEvent>;
+	override listen(event: 'ping'): DemuxedConsumableStream<PingEvent>;
+	override listen(event: 'pong'): DemuxedConsumableStream<PongEvent>;
+	override listen(event: 'removeAuthToken'): DemuxedConsumableStream<RemoveAuthTokenEvent>;
+	override listen(event: 'request'): DemuxedConsumableStream<RequestEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>>;
+	override listen(event: 'response'): DemuxedConsumableStream<ResponseEvent<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>>;
+	override listen<U extends SocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>, V = U>(event: string): DemuxedConsumableStream<V>;
+	override listen<U extends SocketEvent<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>, V = U>(event?: string): DemuxedConsumableStream<V> {
+		return super.listen<U, V>(event ?? '');
 	}
 
 	public ping(): Promise<void> {

--- a/packages/server/src/server-transport.ts
+++ b/packages/server/src/server-transport.ts
@@ -1,7 +1,8 @@
 import { AuthToken, SignedAuthToken } from '@socket-mesh/auth';
 import { AuthTokenOptions } from '@socket-mesh/auth-engine';
 import { ChannelMap, PublishOptions } from '@socket-mesh/channels';
-import { abortRequest, AnyPacket, AnyRequest, AnyResponse, BaseSocketTransport, InboundMessage, PrivateMethodMap, PublicMethodMap, ServiceMap, SocketStatus, toError } from '@socket-mesh/core';
+import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
+import { abortRequest, AnyPacket, AnyRequest, AnyResponse, BaseSocketTransport, FunctionReturnType, InboundMessage, InvokeMethodOptions, InvokeServiceOptions, PrivateMethodMap, PublicMethodMap, ServiceMap, ServiceMethodName, ServiceName, SocketStatus, SocketTransport, toError } from '@socket-mesh/core';
 import { AuthError, BrokerError, InvalidActionError, SocketProtocolErrorStatuses } from '@socket-mesh/errors';
 import base64id from 'base64id';
 import { IncomingMessage } from 'http';
@@ -21,7 +22,15 @@ export class ServerTransport<
 	TPrivateOutgoing extends PrivateMethodMap = {},
 	TServerState extends object = {},
 	TState extends object = {}
-> extends BaseSocketTransport<TState & ServerSocketState> {
+> extends BaseSocketTransport<TState & ServerSocketState>
+	implements SocketTransport<
+		TIncoming & TPrivateIncoming & ServerPrivateMap,
+		TOutgoing,
+		TState & ServerSocketState,
+		TService,
+		{},
+		TPrivateOutgoing & ClientPrivateMap
+	> {
 	public override id: string;
 	public readonly plugins: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[];
 	public readonly request: IncomingMessage;
@@ -72,6 +81,19 @@ export class ServerTransport<
 		}
 
 		return await super.handleInboudMessage({ packet, timestamp });
+	}
+
+	override invoke<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void];
+	override invoke<TMethod extends keyof TOutgoing & string>(options: InvokeMethodOptions<TOutgoing, TMethod>, arg?: Parameters<TOutgoing[TMethod]>[0]): [Promise<FunctionReturnType<TOutgoing[TMethod]>>, () => void];
+	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod, (false | number)?], arg?: Parameters<TService[TServiceName][TMethod]>[0]): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void];
+	override invoke<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: InvokeServiceOptions<TService, TServiceName, TMethod>, arg?: Parameters<TService[TServiceName][TMethod]>[0]): [Promise<FunctionReturnType<TService[TServiceName][TMethod]>>, () => void];
+	override invoke<TMethod extends keyof (TPrivateOutgoing & ClientPrivateMap) & string>(method: TMethod, arg: Parameters<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>[0]): [Promise<FunctionReturnType<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>>, () => void];
+	override invoke<TMethod extends keyof (TPrivateOutgoing & ClientPrivateMap) & string>(options: InvokeMethodOptions<(TPrivateOutgoing & ClientPrivateMap), TMethod>, arg?: Parameters<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>[0]): [Promise<FunctionReturnType<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>>, () => void];
+	override invoke(
+		methodOptions: [string, string, (false | number)?] | InvokeMethodOptions | InvokeServiceOptions | string,
+		arg?: unknown
+	): [Promise<unknown>, () => void] {
+		return super.invoke(methodOptions, arg);
 	}
 
 	protected override onClose(code: number, reason?: Buffer | string): void {
@@ -304,6 +326,16 @@ export class ServerTransport<
 
 	public override set socket(value: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) {
 		super.socket = value;
+	}
+
+	override transmit<TMethod extends keyof TOutgoing & string>(method: TMethod, arg?: Parameters<TOutgoing[TMethod]>[0]): Promise<void>;
+	override transmit<TServiceName extends ServiceName<TService>, TMethod extends ServiceMethodName<TService, TServiceName>>(options: [TServiceName, TMethod], arg?: Parameters<TService[TServiceName][TMethod]>[0]): Promise<void>;
+	override transmit<TMethod extends keyof (TPrivateOutgoing & ClientPrivateMap) & string>(method: TMethod, arg?: Parameters<(TPrivateOutgoing & ClientPrivateMap)[TMethod]>[0]): Promise<void>;
+	override transmit(
+		serviceAndMethod: [string, string] | string,
+		arg?: unknown
+	): Promise<void> {
+		return super.transmit(serviceAndMethod, arg);
 	}
 
 	public override triggerAuthenticationEvents(wasSigned: boolean, wasAuthenticated: boolean): void {

--- a/packages/server/src/server-transport.ts
+++ b/packages/server/src/server-transport.ts
@@ -1,8 +1,7 @@
 import { AuthToken, SignedAuthToken } from '@socket-mesh/auth';
 import { AuthTokenOptions } from '@socket-mesh/auth-engine';
 import { ChannelMap, PublishOptions } from '@socket-mesh/channels';
-import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
-import { abortRequest, AnyPacket, AnyRequest, AnyResponse, InboundMessage, PrivateMethodMap, PublicMethodMap, ServiceMap, SocketStatus, SocketTransport, toError } from '@socket-mesh/core';
+import { abortRequest, AnyPacket, AnyRequest, AnyResponse, BaseSocketTransport, InboundMessage, PrivateMethodMap, PublicMethodMap, ServiceMap, SocketStatus, toError } from '@socket-mesh/core';
 import { AuthError, BrokerError, InvalidActionError, SocketProtocolErrorStatuses } from '@socket-mesh/errors';
 import base64id from 'base64id';
 import { IncomingMessage } from 'http';
@@ -22,13 +21,7 @@ export class ServerTransport<
 	TPrivateOutgoing extends PrivateMethodMap = {},
 	TServerState extends object = {},
 	TState extends object = {}
-> extends SocketTransport<
-	TIncoming & TPrivateIncoming & ServerPrivateMap,
-	TOutgoing,
-	TPrivateOutgoing & ClientPrivateMap,
-	TService,
-	TState & ServerSocketState
-	> {
+> extends BaseSocketTransport<TState & ServerSocketState> {
 	public override id: string;
 	public readonly plugins: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[];
 	public readonly request: IncomingMessage;

--- a/packages/server/src/server-transport.ts
+++ b/packages/server/src/server-transport.ts
@@ -135,13 +135,13 @@ export class ServerTransport<
 		this.socket.server.emit('socketError', { error, socket: this.socket });
 	}
 
-	protected override onInvoke(request: AnyRequest<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>): void {
+	protected override onInvoke(request: AnyRequest): void {
 		if (request.method !== '#publish') {
 			super.onInvoke(request);
 			return;
 		}
 
-		this.onPublish(request.data!)
+		this.onPublish(request.data as PublishOptions)
 			.then(() => {
 				super.onInvoke(request);
 			})
@@ -216,12 +216,12 @@ export class ServerTransport<
 		this.socket.server.emit('socketResponse', { response, socket: this.socket });
 	}
 
-	protected override onTransmit(request: AnyRequest<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>): void {
+	protected override onTransmit(request: AnyRequest): void {
 		if (request.method !== '#publish') {
 			super.onTransmit(request);
 			return;
 		}
-		this.onPublish(request.data!)
+		this.onPublish(request.data as PublishOptions)
 			.then(() => {
 				super.onTransmit(request);
 			})

--- a/packages/server/src/server-transport.ts
+++ b/packages/server/src/server-transport.ts
@@ -15,13 +15,13 @@ import { ServerSocket, ServerSocketOptions } from './server-socket.js';
 
 export class ServerTransport<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
+	TServerState extends object = {}
 > extends BaseSocketTransport<TState & ServerSocketState>
 	implements SocketTransport<
 		TIncoming & TPrivateIncoming & ServerPrivateMap,
@@ -32,13 +32,13 @@ export class ServerTransport<
 		TPrivateOutgoing & ClientPrivateMap
 	> {
 	public override id: string;
-	public readonly plugins: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[];
+	public readonly plugins: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[];
 	public readonly request: IncomingMessage;
 	public readonly service?: string;
 
 	public type: 'server';
 
-	constructor(options: ServerSocketOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) {
+	constructor(options: ServerSocketOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) {
 		super(options);
 
 		this.type = 'server';
@@ -320,11 +320,11 @@ export class ServerTransport<
 		this.socket.server.emit('socketConnect', { authError, id: this.socket.id, isAuthenticated: !!this.signedAuthToken, pingTimeoutMs, socket: this.socket });
 	}
 
-	public override get socket(): ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState> {
-		return super.socket as ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>;
+	public override get socket(): ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState> {
+		return super.socket as ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>;
 	}
 
-	public override set socket(value: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) {
+	public override set socket(value: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) {
 		super.socket = value;
 	}
 

--- a/packages/server/src/server-transport.ts
+++ b/packages/server/src/server-transport.ts
@@ -71,7 +71,7 @@ export class ServerTransport<
 	}
 
 	protected async handleInboudMessage(
-		{ packet, timestamp }: InboundMessage<TIncoming & TPrivateIncoming & ServerPrivateMap, TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>
+		{ packet, timestamp }: InboundMessage
 	): Promise<void> {
 		if ((packet === null || typeof packet !== 'object') && this.socket.server.strictHandshake && this.status === 'connecting') {
 			this.disconnect(4009);
@@ -191,7 +191,7 @@ export class ServerTransport<
 	}
 
 	protected override async onRequest(
-		packet: AnyPacket<TIncoming & TPrivateIncoming & ServerPrivateMap, TService>,
+		packet: AnyPacket,
 		timestamp: Date,
 		pluginError?: Error
 	): Promise<boolean> {
@@ -211,7 +211,7 @@ export class ServerTransport<
 		return wasHandled;
 	}
 
-	protected override onResponse(response: AnyResponse<TOutgoing, TPrivateOutgoing & ClientPrivateMap, TService>): void {
+	protected override onResponse(response: AnyResponse): void {
 		super.onResponse(response);
 		this.socket.server.emit('socketResponse', { response, socket: this.socket });
 	}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,8 +1,8 @@
 import { AsyncStreamEmitter } from '@socket-mesh/async-stream-emitter';
 import { AuthEngine, defaultAuthEngine, isAuthEngine } from '@socket-mesh/auth-engine';
 import { ChannelMap } from '@socket-mesh/channels';
-import { removeAuthTokenHandler, ServerPrivateMap } from '@socket-mesh/client';
-import { CallIdGenerator, HandlerMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode, toError } from '@socket-mesh/core';
+import { removeAuthTokenHandler } from '@socket-mesh/client';
+import { CallIdGenerator, LooseHandlerMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode, toError } from '@socket-mesh/core';
 import { ServerProtocolError } from '@socket-mesh/errors';
 import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
@@ -20,9 +20,7 @@ import { subscribeHandler } from './handlers/subscribe.js';
 import { unsubscribeHandler } from './handlers/unsubscribe.js';
 import { ServerPlugin } from './plugin/server-plugin.js';
 import { ServerOptions } from './server-options.js';
-import { ServerSocketState } from './server-socket-state.js';
 import { ServerSocket } from './server-socket.js';
-import { ServerTransport } from './server-transport.js';
 
 export class Server<
 	TIncoming extends PublicMethodMap = {},
@@ -35,13 +33,7 @@ export class Server<
 	TState extends object = {}
 > extends AsyncStreamEmitter<ServerEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>> {
 	private readonly _callIdGenerator: CallIdGenerator;
-	private _handlers:
-	HandlerMap<
-			TIncoming & TPrivateIncoming & ServerPrivateMap,
-			TState & ServerSocketState,
-			ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
-			ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
-	>;
+	private _handlers: LooseHandlerMap;
 
 	private _isListening: boolean;
 	private _isReady: boolean;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -24,14 +24,14 @@ import { ServerSocket } from './server-socket.js';
 
 export class Server<
 	TIncoming extends PublicMethodMap = {},
+	TOutgoing extends PublicMethodMap = {},
 	TChannel extends ChannelMap = {},
 	TService extends ServiceMap = {},
-	TOutgoing extends PublicMethodMap = {},
+	TState extends object = {},
 	TPrivateIncoming extends PrivateMethodMap = {},
 	TPrivateOutgoing extends PrivateMethodMap = {},
-	TServerState extends object = {},
-	TState extends object = {}
-> extends AsyncStreamEmitter<ServerEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>> {
+	TServerState extends object = {}
+> extends AsyncStreamEmitter<ServerEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>> {
 	private readonly _callIdGenerator: CallIdGenerator;
 	private _handlers: LooseHandlerMap;
 
@@ -46,23 +46,23 @@ export class Server<
 	public readonly auth: AuthEngine;
 	public readonly brokerEngine!: Broker<TChannel>;
 	public clientCount: number;
-	public readonly clients: { [ id: string ]: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState> };
+	public readonly clients: { [ id: string ]: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState> };
 	public readonly codecEngine: CodecEngine;
 	public readonly httpServer: HttpServer;
 
 	public isPingTimeoutDisabled: boolean;
 	public origins: string;
 	public pendingClientCount: number;
-	public readonly pendingClients: { [ id: string ]: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState> };
+	public readonly pendingClients: { [ id: string ]: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState> };
 	public pingIntervalMs: number;
 	public pingTimeoutMs: number;
-	public readonly plugins: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[];
+	public readonly plugins: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[];
 	public socketChannelLimit?: number;
 	public readonly socketStreamCleanupMode: StreamCleanupMode;
 
 	public strictHandshake: boolean;
 
-	constructor(options?: ServerOptions<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) {
+	constructor(options?: ServerOptions<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) {
 		super();
 
 		let cid = 1;
@@ -144,11 +144,11 @@ export class Server<
 		}
 	}
 
-	public addPlugin(...plugin: ServerPlugin<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>[]): void {
+	public addPlugin(...plugin: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[]): void {
 		this.plugins.push(...plugin);
 	}
 
-	private bind(socket: ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>) {
+	private bind(socket: ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>) {
 		/*
 		if (socket.type === 'client') {
 			(async () => {
@@ -224,33 +224,33 @@ export class Server<
 	}
 
 	emit(event: 'close', data: CloseEvent): void;
-	emit(event: 'connection', data: ConnectionEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
+	emit(event: 'connection', data: ConnectionEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
 	emit(event: 'error', data: ErrorEvent): void;
 	emit(event: 'headers', data: HeadersEvent): void;
-	emit(event: 'handshake', data: HandshakeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
+	emit(event: 'handshake', data: HandshakeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
 	emit(event: 'listening', data: ListeningEvent): void;
 	emit(event: 'ready', data: {}): void;
-	emit(event: 'socketAuthStateChange', data: SocketAuthStateChangeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketAuthenticate', data: SocketAuthenticateEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketBadAuthToken', data: SocketBadAuthTokenEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketClose', data: SocketCloseEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketConnect', data: SocketConnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketConnectAbort', data: SocketDisconnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketConnecting', data: SocketConnectingEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketDeauthenticate', data: SocketDeauthenticateEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketDisconnect', data: SocketDisconnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketError', data: SocketErrorEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketMessage', data: SocketMessageEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketPing', data: SocketPingEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketPong', data: SocketPongEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketRemoveAuthToken', data: SocketRemoveAuthTokenEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketRequest', data: SocketRequestEvent<TService, TIncoming, TPrivateIncoming>): void;
-	emit(event: 'socketResponse', data: SocketResponseEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketSubscribe', data: SocketSubscribeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketSubscribeFail', data: SocketSubscribeFailEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketSubscribeRequest', data: SocketSubscribeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketSubscribeStateChange', data: SocketSubscribeStateChangeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
-	emit(event: 'socketUnsubscribe', data: SocketUnsubscribeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>): void;
+	emit(event: 'socketAuthStateChange', data: SocketAuthStateChangeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketAuthenticate', data: SocketAuthenticateEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketBadAuthToken', data: SocketBadAuthTokenEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketClose', data: SocketCloseEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketConnect', data: SocketConnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketConnectAbort', data: SocketDisconnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketConnecting', data: SocketConnectingEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketDeauthenticate', data: SocketDeauthenticateEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketDisconnect', data: SocketDisconnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketError', data: SocketErrorEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketMessage', data: SocketMessageEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketPing', data: SocketPingEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketPong', data: SocketPongEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketRemoveAuthToken', data: SocketRemoveAuthTokenEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketRequest', data: SocketRequestEvent<TIncoming, TService, TPrivateIncoming>): void;
+	emit(event: 'socketResponse', data: SocketResponseEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketSubscribe', data: SocketSubscribeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketSubscribeFail', data: SocketSubscribeFailEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketSubscribeRequest', data: SocketSubscribeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketSubscribeStateChange', data: SocketSubscribeStateChangeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
+	emit(event: 'socketUnsubscribe', data: SocketUnsubscribeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>): void;
 	emit(event: 'warning', data: WarningEvent): void;
 	emit(event: string, data: any): void {
 		super.emit(event, data);
@@ -268,37 +268,37 @@ export class Server<
 		return this._isReady;
 	}
 
-	listen(): DemuxedConsumableStream<StreamEvent<ServerEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>>;
+	listen(): DemuxedConsumableStream<StreamEvent<ServerEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>>;
 	listen(event: 'close'): DemuxedConsumableStream<CloseEvent>;
-	listen(event: 'connection'): DemuxedConsumableStream<ConnectionEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
+	listen(event: 'connection'): DemuxedConsumableStream<ConnectionEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
 	listen(event: 'error'): DemuxedConsumableStream<ErrorEvent>;
-	listen(event: 'handshake'): DemuxedConsumableStream<HandshakeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
+	listen(event: 'handshake'): DemuxedConsumableStream<HandshakeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
 	listen(event: 'headers'): DemuxedConsumableStream<HeadersEvent>;
 	listen(event: 'listening'): DemuxedConsumableStream<ListeningEvent>;
 	listen(event: 'ready'): DemuxedConsumableStream<{}>;
-	listen(event: 'socketAuthStateChange'): DemuxedConsumableStream<SocketAuthStateChangeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketAuthenticate'): DemuxedConsumableStream<SocketAuthenticateEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketBadAuthToken'): DemuxedConsumableStream<SocketBadAuthTokenEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketClose'): DemuxedConsumableStream<SocketCloseEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketConnect'): DemuxedConsumableStream<SocketConnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketConnectAbort'): DemuxedConsumableStream<SocketDisconnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketConnecting'): DemuxedConsumableStream<SocketConnectingEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketDeauthenticate'): DemuxedConsumableStream<SocketDeauthenticateEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketDisconnect'): DemuxedConsumableStream<SocketDisconnectEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketError'): DemuxedConsumableStream<SocketErrorEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketMessage'): DemuxedConsumableStream<SocketMessageEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketPing'): DemuxedConsumableStream<SocketPingEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketPong'): DemuxedConsumableStream<SocketPongEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketRemoveAuthToken'): DemuxedConsumableStream<SocketRemoveAuthTokenEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketRequest'): DemuxedConsumableStream<SocketRequestEvent<TService, TIncoming, TPrivateIncoming>>;
-	listen(event: 'socketResponse'): DemuxedConsumableStream<SocketResponseEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketSubscribe'): DemuxedConsumableStream<SocketSubscribeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketSubscribeFail'): DemuxedConsumableStream<SocketSubscribeFailEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketSubscribeRequest'): DemuxedConsumableStream<SocketSubscribeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketSubscribeStateChange'): DemuxedConsumableStream<SocketSubscribeStateChangeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
-	listen(event: 'socketUnsubscribe'): DemuxedConsumableStream<SocketUnsubscribeEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>>;
+	listen(event: 'socketAuthStateChange'): DemuxedConsumableStream<SocketAuthStateChangeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketAuthenticate'): DemuxedConsumableStream<SocketAuthenticateEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketBadAuthToken'): DemuxedConsumableStream<SocketBadAuthTokenEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketClose'): DemuxedConsumableStream<SocketCloseEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketConnect'): DemuxedConsumableStream<SocketConnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketConnectAbort'): DemuxedConsumableStream<SocketDisconnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketConnecting'): DemuxedConsumableStream<SocketConnectingEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketDeauthenticate'): DemuxedConsumableStream<SocketDeauthenticateEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketDisconnect'): DemuxedConsumableStream<SocketDisconnectEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketError'): DemuxedConsumableStream<SocketErrorEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketMessage'): DemuxedConsumableStream<SocketMessageEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketPing'): DemuxedConsumableStream<SocketPingEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketPong'): DemuxedConsumableStream<SocketPongEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketRemoveAuthToken'): DemuxedConsumableStream<SocketRemoveAuthTokenEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketRequest'): DemuxedConsumableStream<SocketRequestEvent<TIncoming, TService, TPrivateIncoming>>;
+	listen(event: 'socketResponse'): DemuxedConsumableStream<SocketResponseEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketSubscribe'): DemuxedConsumableStream<SocketSubscribeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketSubscribeFail'): DemuxedConsumableStream<SocketSubscribeFailEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketSubscribeRequest'): DemuxedConsumableStream<SocketSubscribeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketSubscribeStateChange'): DemuxedConsumableStream<SocketSubscribeStateChangeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
+	listen(event: 'socketUnsubscribe'): DemuxedConsumableStream<SocketUnsubscribeEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>>;
 	listen(event: 'warning'): DemuxedConsumableStream<WarningEvent>;
-	listen(event?: string): DemuxedConsumableStream<ServerEvent<TChannel, TService, TIncoming, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>> | DemuxedConsumableStream<StreamEvent<any>> {
+	listen(event?: string): DemuxedConsumableStream<ServerEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>> | DemuxedConsumableStream<StreamEvent<any>> {
 		return event ? super.listen(event) : super.listen();
 	}
 
@@ -314,7 +314,7 @@ export class Server<
 			wsSocket.upgradeReq = upgradeReq;
 		}
 */
-		const socket = new ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>({
+		const socket = new ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>({
 			ackTimeoutMs: this.ackTimeoutMs,
 			callIdGenerator: this._callIdGenerator,
 			codecEngine: this.codecEngine,
@@ -358,8 +358,8 @@ export class Server<
 
 	private socketDisconnected(
 		socket:
-		// ClientSocket<PublicMethodMap, TChannel, TService, TState, TOutgoing & TPrivateOutgoing, TPrivateIncoming> |
-		ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
+		// ClientSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateOutgoing> |
+		ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 	): void {
 		if (this.pendingClients[socket.id]) {
 			delete this.pendingClients[socket.id];

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,7 @@
 import { AsyncStreamEmitter } from '@socket-mesh/async-stream-emitter';
 import { AuthEngine, defaultAuthEngine, isAuthEngine } from '@socket-mesh/auth-engine';
 import { ChannelMap } from '@socket-mesh/channels';
-import { ClientPrivateMap, removeAuthTokenHandler, ServerPrivateMap } from '@socket-mesh/client';
+import { removeAuthTokenHandler, ServerPrivateMap } from '@socket-mesh/client';
 import { CallIdGenerator, HandlerMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode, toError } from '@socket-mesh/core';
 import { ServerProtocolError } from '@socket-mesh/errors';
 import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
@@ -22,6 +22,7 @@ import { ServerPlugin } from './plugin/server-plugin.js';
 import { ServerOptions } from './server-options.js';
 import { ServerSocketState } from './server-socket-state.js';
 import { ServerSocket } from './server-socket.js';
+import { ServerTransport } from './server-transport.js';
 
 export class Server<
 	TIncoming extends PublicMethodMap = {},
@@ -37,10 +38,9 @@ export class Server<
 	private _handlers:
 	HandlerMap<
 			TIncoming & TPrivateIncoming & ServerPrivateMap,
-			TOutgoing,
-			TPrivateOutgoing & ClientPrivateMap,
-			TService,
-			TState & ServerSocketState
+			TState & ServerSocketState,
+			ServerSocket<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>,
+			ServerTransport<TIncoming, TChannel, TService, TOutgoing, TPrivateIncoming, TPrivateOutgoing, TServerState, TState>
 	>;
 
 	private _isListening: boolean;

--- a/tests/integration/src/client.spec.ts
+++ b/tests/integration/src/client.spec.ts
@@ -43,8 +43,8 @@ const allowedUsers: { [name: string]: true } = {
 	kate: true
 };
 
-let client: ClientSocket<ServerIncomingMap, MyChannels>;
-let server: Server<ServerIncomingMap, MyChannels>;
+let client: ClientSocket<{}, ServerIncomingMap, MyChannels>;
+let server: Server<ServerIncomingMap, {}, MyChannels>;
 
 let wasPerformTaskTriggered: boolean;
 
@@ -80,7 +80,7 @@ const clientOptions: ClientSocketOptions = {
 
 describe('Client Tests', function () {
 	beforeEach(async function () {
-		server = listen<ServerIncomingMap, MyChannels>(
+		server = listen<ServerIncomingMap, {}, MyChannels>(
 			PORT_NUMBER,
 			{
 				ackTimeoutMs: 200,
@@ -775,7 +775,7 @@ describe('Client Tests', function () {
 	});
 
 	describe('Pub/sub', function () {
-		let publisherClient: ClientSocket<ServerIncomingMap, MyChannels>;
+		let publisherClient: ClientSocket<{}, ServerIncomingMap, MyChannels>;
 		const lastServerMessage: null | string = null;
 
 		beforeEach(async function () {

--- a/tests/integration/src/client.spec.ts
+++ b/tests/integration/src/client.spec.ts
@@ -72,7 +72,7 @@ async function setAuthKeyHandler({ options: secret, socket }: ServerRequestHandl
 	socket.server!.auth.authKey = secret;
 }
 
-const clientOptions: ClientSocketOptions<ServerIncomingMap> = {
+const clientOptions: ClientSocketOptions = {
 	ackTimeoutMs: 200,
 	address: `ws://127.0.0.1:${PORT_NUMBER}`,
 	authEngine: { authTokenName: AUTH_TOKEN_NAME }

--- a/tests/integration/src/server.spec.ts
+++ b/tests/integration/src/server.spec.ts
@@ -3091,7 +3091,7 @@ describe('Server Tests', function () {
 		describe('onMessage', function () {
 			it('Should run INVOKE action in plugin if client invokes an RPC', async function () {
 				let wasPluginExecuted = false;
-				let pluginPacket: MethodRequestPacket<ServerIncomingMap & ServerPrivateMap, 'proc'> | null = null;
+				let pluginPacket: MethodRequestPacket | null = null;
 
 				server.addPlugin({
 					async onMessage({ packet }) {
@@ -3118,7 +3118,7 @@ describe('Server Tests', function () {
 
 			it('Should send back custom Error if INVOKE action in plugin blocks the client RPC', async function () {
 				let wasPluginExecuted = false;
-				let pluginPacket: AnyPacket<ServerIncomingMap & ServerPrivateMap, {}> | null = null;
+				let pluginPacket: AnyPacket | null = null;
 
 				server.addPlugin({
 					async onMessage({ packet }) {

--- a/tests/integration/src/server.spec.ts
+++ b/tests/integration/src/server.spec.ts
@@ -61,7 +61,7 @@ type ServerIncomingMap = {
 	setAuthKey: (secret: jwt.Secret) => void
 };
 
-function bindFailureHandlers(server: Server<ServerIncomingMap, MyChannels, {}, ClientIncomingMap>) {
+function bindFailureHandlers(server: Server<ServerIncomingMap, ClientIncomingMap, MyChannels>) {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 	if (SHOULD_LOG_ERRORS) {
 		(async () => {
@@ -154,7 +154,7 @@ const clientOptions: ClientSocketOptions = {
 	authEngine: { authTokenName: AUTH_TOKEN_NAME }
 };
 
-const serverOptions: ServerOptions<ServerIncomingMap, MyChannels, {}, ClientIncomingMap> = {
+const serverOptions: ServerOptions<ServerIncomingMap, ClientIncomingMap, MyChannels> = {
 	ackTimeoutMs: 200,
 	authEngine: { authKey: SERVER_AUTH_KEY },
 	handlers: {
@@ -168,8 +168,8 @@ const serverOptions: ServerOptions<ServerIncomingMap, MyChannels, {}, ClientInco
 	}
 };
 
-let client: ClientSocket<ServerIncomingMap, MyChannels>;
-let server: Server<ServerIncomingMap, MyChannels, {}, ClientIncomingMap>;
+let client: ClientSocket<{}, ServerIncomingMap, MyChannels>;
+let server: Server<ServerIncomingMap, ClientIncomingMap, MyChannels>;
 
 describe('Server Tests', function () {
 	afterEach(async function () {
@@ -250,7 +250,7 @@ describe('Server Tests', function () {
 
 			const authenticateEvents: (AuthToken | null)[] = [];
 			const deauthenticateEvents: (AuthToken | null)[] = [];
-			const authenticationStateChangeEvents: SocketAuthStateChangeEvent<MyChannels, {}, ServerIncomingMap, ClientIncomingMap, {}, {}, {}, {}>[] = [];
+			const authenticationStateChangeEvents: SocketAuthStateChangeEvent<ServerIncomingMap, ClientIncomingMap, MyChannels, {}, {}, {}, {}, {}>[] = [];
 			const authStateChangeEvents: AuthStateChangeEvent[] = [];
 
 			(async () => {
@@ -320,7 +320,7 @@ describe('Server Tests', function () {
 		it('Should emit correct events/data when socket is deauthenticated', async function () {
 			global.localStorage.setItem(AUTH_TOKEN_NAME, VALID_SIGNED_AUTH_TOKEN_BOB);
 
-			const authenticationStateChangeEvents: SocketAuthStateChangeEvent<MyChannels, {}, ServerIncomingMap, ClientIncomingMap, {}, {}, {}, {}>[] = [];
+			const authenticationStateChangeEvents: SocketAuthStateChangeEvent<ServerIncomingMap, ClientIncomingMap, MyChannels, {}, {}, {}, {}, {}>[] = [];
 			const authStateChangeEvents: AuthStateChangeEvent[] = [];
 
 			(async () => {
@@ -834,7 +834,7 @@ describe('Server Tests', function () {
 
 			client = new ClientSocket(clientOptions);
 
-			let serverSocket: null | ServerSocket<ServerIncomingMap, MyChannels, {}, ClientIncomingMap> = null;
+			let serverSocket: null | ServerSocket<ServerIncomingMap, ClientIncomingMap, MyChannels> = null;
 
 			(async () => {
 				for await (const { socket } of server.listen('handshake')) {
@@ -1071,7 +1071,7 @@ describe('Server Tests', function () {
 			server = listen(PORT_NUMBER, serverOptions);
 			bindFailureHandlers(server);
 
-			const connectionList: ConnectionEvent<MyChannels, {}, ServerIncomingMap, ClientIncomingMap, {}, {}, {}, {}>[] = [];
+			const connectionList: ConnectionEvent<ServerIncomingMap, ClientIncomingMap, MyChannels, {}, {}, {}, {}, {}>[] = [];
 
 			(async () => {
 				for await (const event of server.listen('connection')) {
@@ -1081,8 +1081,8 @@ describe('Server Tests', function () {
 
 			await server.listen('ready').once();
 
-			const clientList: ClientSocket<ServerIncomingMap, MyChannels>[] = [];
-			let client: ClientSocket<ServerIncomingMap, MyChannels>;
+			const clientList: ClientSocket<{}, ServerIncomingMap, MyChannels>[] = [];
+			let client: ClientSocket<{}, ServerIncomingMap, MyChannels>;
 
 			for (let i = 0; i < 100; i++) {
 				client = new ClientSocket(clientOptions);
@@ -1127,8 +1127,8 @@ describe('Server Tests', function () {
 
 			await server.listen('ready').once();
 
-			const clientList: ClientSocket<ServerIncomingMap, MyChannels>[] = [];
-			let client: ClientSocket<ServerIncomingMap, MyChannels>;
+			const clientList: ClientSocket<{}, ServerIncomingMap, MyChannels>[] = [];
+			let client: ClientSocket<{}, ServerIncomingMap, MyChannels>;
 
 			for (let i = 0; i < 100; i++) {
 				client = new ClientSocket({
@@ -1444,7 +1444,7 @@ describe('Server Tests', function () {
 					...serverOptions,
 					handlers: {
 						foo: async ({ options: data, socket }: RequestHandlerArgs<number>) => {
-							const typedSocket = socket as ServerSocket<ServerIncomingMap, MyChannels, {}, ClientIncomingMap>;
+							const typedSocket = socket as ServerSocket<ServerIncomingMap, ClientIncomingMap, MyChannels>;
 							currentRequestData = data;
 							await wait(10);
 							(async () => {
@@ -2441,7 +2441,7 @@ describe('Server Tests', function () {
 			bindFailureHandlers(server);
 
 			const errorList: Error[] = [];
-			let serverSocket: ServerSocket<ServerIncomingMap, MyChannels, {}, ClientIncomingMap>;
+			let serverSocket: ServerSocket<ServerIncomingMap, ClientIncomingMap, MyChannels>;
 			let wasKickOutCalled = false;
 
 			(async () => {

--- a/tests/integration/src/server.spec.ts
+++ b/tests/integration/src/server.spec.ts
@@ -2499,7 +2499,7 @@ describe('Server Tests', function () {
 							// Each subscription should pass through the plugin individually, even
 							// though they were sent as a batch/array.
 							async onMessage({ packet }) {
-								if (isRequestPacket(packet) && packet.method === '#subscribe') {
+								if (isRequestPacket<ServerPrivateMap>(packet) && packet.method === '#subscribe') {
 									subscribePluginCounter++;
 									assert.strictEqual(packet.data.channel.indexOf('my-channel-'), 0);
 									if (packet.data.channel === 'my-channel-10') {

--- a/tests/integration/src/server.spec.ts
+++ b/tests/integration/src/server.spec.ts
@@ -1,11 +1,11 @@
 import { AuthToken } from '@socket-mesh/auth';
 import { Channel, ChannelOptions, isPublishOptions, JsonValue, UnsubscribeEvent } from '@socket-mesh/channels';
-import { ClientPrivateMap, ClientSocket, ClientSocketOptions } from '@socket-mesh/client';
+import { ClientSocket, ClientSocketOptions } from '@socket-mesh/client';
 import { InOrderPlugin, OfflinePlugin, RequestBatchingPlugin, ResponseBatchingPlugin, ServerPrivateMap } from '@socket-mesh/client';
 import { AnyPacket, AuthenticatedChangeEvent, AuthStateChangeEvent, CloseEvent, ConnectEvent, DisconnectEvent, isRequestPacket, MethodRequestPacket, PluginArgs, RequestHandlerArgs, SendRequestPluginArgs, toError, wait } from '@socket-mesh/core';
 import { HandshakeError, PluginBlockedError } from '@socket-mesh/errors';
 import localStorage from '@socket-mesh/local-storage';
-import { listen, Server, ServerOptions, ServerSocket, ServerSocketState } from '@socket-mesh/server';
+import { listen, Server, ServerOptions, ServerSocket } from '@socket-mesh/server';
 import { ExchangeClient, SimpleBroker } from '@socket-mesh/server/broker';
 import { ConnectionEvent, SocketAuthStateChangeEvent } from '@socket-mesh/server/events';
 import { AuthInfo, ServerRequestHandlerArgs } from '@socket-mesh/server/handlers';
@@ -149,7 +149,7 @@ async function setAuthKeyHandler({ options: secret, socket }: ServerRequestHandl
 	socket.server!.auth.authKey = secret;
 }
 
-const clientOptions: ClientSocketOptions<ServerIncomingMap> = {
+const clientOptions: ClientSocketOptions = {
 	address: `ws://127.0.0.1:${PORT_NUMBER}`,
 	authEngine: { authTokenName: AUTH_TOKEN_NAME }
 };
@@ -383,7 +383,7 @@ describe('Server Tests', function () {
 			try {
 				await socket.deauthenticate(true);
 			} catch (err) {
-				error = err;
+				error = toError(err);
 			}
 
 			assert.notEqual(error, null);
@@ -660,7 +660,7 @@ describe('Server Tests', function () {
 									socket.disconnect();
 									await transport.setAuthorization(authToken, { rejectOnFailedDelivery: true });
 								} catch (err) {
-									error = err;
+									error = toError(err);
 								}
 
 								try {
@@ -675,7 +675,7 @@ describe('Server Tests', function () {
 									assert.strictEqual(serverWarnings[1]!.name, 'AuthError');
 									resolve();
 								} catch (err) {
-									reject(err);
+									reject(toError(err));
 								}
 							})();
 						}
@@ -729,7 +729,7 @@ describe('Server Tests', function () {
 									socket.disconnect();
 									await transport.setAuthorization(authToken);
 								} catch (err) {
-									error = err;
+									error = toError(err);
 								}
 
 								try {
@@ -740,7 +740,7 @@ describe('Server Tests', function () {
 
 									resolve();
 								} catch (err) {
-									reject(err);
+									reject(toError(err));
 								}
 							})();
 						}
@@ -790,7 +790,7 @@ describe('Server Tests', function () {
 								// assert.notEqual(verifyOptions, null);
 								// assert.notEqual(options.socket, null);
 							} catch (err) {
-								reject(err);
+								reject(toError(err));
 							}
 							resolve();
 							return {};
@@ -868,7 +868,7 @@ describe('Server Tests', function () {
 					plugins: [
 						new OfflinePlugin(),
 						{
-							sendRequest: ({ cont, requests }: SendRequestPluginArgs<ClientPrivateMap, {}, ServerPrivateMap, {}, { }>) => {
+							sendRequest: ({ cont, requests }: SendRequestPluginArgs) => {
 								cont(
 									requests.map(
 										(req) => {
@@ -926,7 +926,7 @@ describe('Server Tests', function () {
 			client = new ClientSocket(
 				{
 					plugins: [{
-						onOpen({ transport }: PluginArgs<ClientPrivateMap, {}, ServerPrivateMap, {}, { }>) {
+						onOpen({ transport }: PluginArgs) {
 							transport.send(Buffer.alloc(0));
 						},
 						type: 'onOpen'
@@ -954,7 +954,7 @@ describe('Server Tests', function () {
 			client = new ClientSocket(
 				{
 					plugins: [{
-						onOpen({ transport }: PluginArgs<ClientPrivateMap, {}, ServerPrivateMap, {}, { }>) {
+						onOpen({ transport }: PluginArgs) {
 							transport.send('');
 						},
 						type: 'onOpen'
@@ -981,7 +981,7 @@ describe('Server Tests', function () {
 			client = new ClientSocket(
 				{
 					plugins: [{
-						onOpen({ transport }: PluginArgs<ClientPrivateMap, {}, ServerPrivateMap, {}, { }>) {
+						onOpen({ transport }: PluginArgs) {
 							transport.send(Buffer.alloc(0));
 						},
 						type: 'onOpen'
@@ -1443,17 +1443,18 @@ describe('Server Tests', function () {
 					plugins: [new InOrderPlugin()],
 					...serverOptions,
 					handlers: {
-						foo: async ({ options: data, socket }: RequestHandlerArgs<number, { }, ClientIncomingMap>) => {
+						foo: async ({ options: data, socket }: RequestHandlerArgs<number>) => {
+							const typedSocket = socket as ServerSocket<ServerIncomingMap, MyChannels, {}, ClientIncomingMap>;
 							currentRequestData = data;
 							await wait(10);
 							(async () => {
 								try {
-									await socket.invoke('bla', data);
+									await typedSocket.invoke('bla', data);
 								} catch (err) {}
 							})();
 
 							try {
-								await socket.transmit('hi', data);
+								await typedSocket.transmit('hi', data);
 							} catch (err) {}
 
 							if (data === 10) {
@@ -1725,7 +1726,7 @@ describe('Server Tests', function () {
 			try {
 				result = await client.invoke('customProc', { bad: true });
 			} catch (err) {
-				error = err;
+				error = toError(err);
 			}
 			assert.notEqual(error, null);
 			assert.strictEqual(error!.name, 'BadCustomError');
@@ -1815,7 +1816,7 @@ describe('Server Tests', function () {
 		it('Should be able to getOutboundBackpressure() on a socket object', async function () {
 			const backpressureHistory: number[] = [];
 			const requestStream =
-				new WritableConsumableStream<SendRequestPluginArgs<ServerIncomingMap & ServerPrivateMap, ClientIncomingMap, ClientPrivateMap, {}, ServerSocketState>>();
+				new WritableConsumableStream<SendRequestPluginArgs>();
 
 			(async () => {
 				for await (const { cont, requests } of requestStream) {
@@ -3024,7 +3025,7 @@ describe('Server Tests', function () {
 						try {
 							await transport.setAuthorization({ username: 'alice' });
 						} catch (error) {
-							setAuthTokenError = error;
+							setAuthTokenError = toError(error);
 						}
 					},
 					type: 'Handshake Plugin'
@@ -3257,7 +3258,7 @@ describe('Server Tests', function () {
 				try {
 					await client.channels.invokePublish('hello', 'world');
 				} catch (err) {
-					error = err;
+					error = toError(err);
 				}
 				await wait(100);
 


### PR DESCRIPTION
## Summary

Splits the socket/transport surface so plugin authors can choose loose or strongly typed signatures without forcing every plugin to carry method-map generics.

- **Loosen runtime base classes** — base `invoke`/`transmit`/`listen`/`emit` accept `string | unknown` with no generic constraints. Public-facing typed `invoke`/`transmit` overloads move up to `ClientSocket` (public maps only) and `ServerSocket` (public + private, since internal callers like `deauthenticate`, `kickOut`, broker `#publish` need private methods).
- **Rename loose runtime classes** — `Socket` → `BaseSocket`, `SocketTransport` → `BaseSocketTransport`.
- **Add typed `Socket` / `SocketTransport` aliases** — pure type-layer overlays (`Omit<BaseSocket, 'invoke' | 'listen' | 'transmit'> & { …typed overloads }`) parameterized by `<TIncoming, TOutgoing, TState, TService, TPrivateIncoming, TPrivateOutgoing>`.
- **Re-shape `Plugin` / `PluginArgs`** — both are now generic over `<TSocket, TTransport>` instead of separate method-map generics. `Plugin.handlers?` becomes a shared `LooseHandlerMap` alias extracted to `request-handler.ts`. New `AnyPlugin = Plugin<any, any>` is the storage type used by `BaseSocketTransport.plugins`.
- **`ServerPlugin` is typed for free** — now extends `Plugin<ServerSocket<…>, ServerTransport<…>>`, so inherited `onMessage`/`onAuthenticated`/etc. hooks receive a fully typed `ServerSocket`/`ServerTransport` with access to `socket.server`, `socket.exchange`, etc.
- **Split request/response/socket events into loose and typed variants** — mirrors the `RequestEvent`/`TypedRequestEvent` pattern; loose events at the base layer, narrowed at `ClientSocket`/`ServerSocket` subclasses.
- **Add typed `isRequestPacket` overload** for opt-in narrowing.
- **Strongly type `ClientChannels._transport`** — declared as the typed `SocketTransport<{}, {}, TState, {}, {}, ServerPrivateMap>` alias so internal `transmit('#publish', …)` / `invoke({ method: '#subscribe' }, …)` calls type-check against `ServerPrivateMap`.
- **Default `ServerRequestHandlerArgs` generics to `any`** — breaks the recursive variance loop (`ServerSocket<X>.server` → `Server<X>._handlers` → `RequestHandler<…, ServerSocket<X>>`) so handlers using the abbreviated `ServerRequestHandlerArgs<MyOptions>` form remain assignable to slots with concrete generics, without losing typed handler propagation through `Server._handlers`.
- **Fix pre-existing formatter test** — drop circular `@socket-mesh/core` import in favor of the inline err-to-Error pattern already used in the file.

Existing loose plugins keep working unchanged. New plugin authors can pick the precision they need: loose `Plugin`, typed `Plugin<Socket<MyIn, MyOut>, SocketTransport<MyIn, MyOut>>`, or concrete `Plugin<ServerSocket<MyIn>, ServerTransport<MyIn>>`.

## Test plan

- [x] `pnpm -r build` — all packages build clean
- [x] `pnpm --filter @socket-mesh/core --filter @socket-mesh/client --filter @socket-mesh/server lint` clean
- [x] `pnpm --filter ./tests/integration exec tsc --noEmit` — 0 errors (was 19 baseline)
- [x] `pnpm --filter ./tests/integration test` — 115 pass / 0 fail
- [x] `pnpm --filter @socket-mesh/formatter test` — 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
