### PR TITLE
Dynamic service handlers + cluster broker

### DIFF
--- a/config/typescript-config/tsconfig.build.json
+++ b/config/typescript-config/tsconfig.build.json
@@ -9,6 +9,7 @@
 			"@socket-mesh/auth-engine": ["../../packages/auth-engine/dist/index.d.ts"],
 			"@socket-mesh/channels": ["../../packages/channels/dist/index.d.ts"],
 			"@socket-mesh/client": ["../../packages/client/dist/index.d.ts"],
+			"@socket-mesh/cluster-broker": ["../../packages/cluster-broker/dist/index.d.ts"],
 			"@socket-mesh/consumable-stream": ["../../packages/consumable-stream/dist/index.d.ts"],
 			"@socket-mesh/core": ["../../packages/core/dist/index.d.ts"],
 			"@socket-mesh/errors": ["../../packages/errors/dist/index.d.ts"],

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@socket-mesh/client",
 	"description": "A TCP socket pair for easily transmitting full messages without worrying about request size limits.",
-	"version": "19.0.0",
+	"version": "19.1.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/cluster-broker/package.json
+++ b/packages/cluster-broker/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@socket-mesh/cluster-broker",
 	"description": "Cross-process pub/sub broker for SocketMesh. Provides a Broker<T> implementation that relays channel messages between worker processes through a dedicated broker process over a loopback TCP socket.",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/cluster-broker/package.json
+++ b/packages/cluster-broker/package.json
@@ -1,0 +1,54 @@
+{
+	"name": "@socket-mesh/cluster-broker",
+	"description": "Cross-process pub/sub broker for SocketMesh. Provides a Broker<T> implementation that relays channel messages between worker processes through a dedicated broker process over a loopback TCP socket.",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": ["./dist"],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"author": {
+		"name": "Greg Kimmy"
+	},
+	"scripts": {
+		"build": "node ../../scripts/build.mjs && tsc --project tsconfig.build.json",
+		"deploy": "node ../../scripts/publish.mjs",
+		"lint": "eslint . --c ../../eslint.config.mjs",
+		"lint:fix": "eslint . --c ../../eslint.config.mjs --fix",
+		"test": "tsx --tsconfig ./tsconfig.build.json --test ./src/**/*.{spec,test}.ts ./test/**/*.{spec,test}.ts"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/socket-mesh/client-server.git"
+	},
+	"bugs": {
+		"url": "https://github.com/socket-mesh/client-server/labels/cluster-broker"
+	},
+	"devDependencies": {
+		"@socket-mesh/typescript-config": "workspace:^",
+		"@types/node": "catalog:node"
+	},
+	"dependencies": {
+		"@socket-mesh/async-stream-emitter": "workspace:^",
+		"@socket-mesh/channels": "workspace:^",
+		"@socket-mesh/formatter": "workspace:^",
+		"@socket-mesh/server": "workspace:^",
+		"@socket-mesh/stream-demux": "workspace:^"
+	},
+	"keywords": [
+		"cluster",
+		"broker",
+		"pubsub",
+		"ipc",
+		"socket-mesh"
+	],
+	"engines": {
+		"node": ">= 18.0.0"
+	}
+}

--- a/packages/cluster-broker/src/cluster-broker-host.ts
+++ b/packages/cluster-broker/src/cluster-broker-host.ts
@@ -1,0 +1,278 @@
+import { AsyncStreamEmitter } from '@socket-mesh/async-stream-emitter';
+import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
+import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
+import { AddressInfo, createServer, Server as NetServer, Socket as NetSocket } from 'net';
+
+import { ClusterBrokerHostOptions } from './cluster-broker-options.js';
+import { encodeFrame, FrameDecoder } from './frame-codec.js';
+import { PublishMessage, WireMessage } from './wire.js';
+
+export type ClusterBrokerHostEvent =
+	| HostErrorEvent
+	| HostListeningEvent
+	| HostPublishEvent
+	| HostWorkerConnectEvent
+	| HostWorkerDisconnectEvent;
+
+export interface HostErrorEvent {
+	error: Error,
+	workerId?: string
+}
+
+export interface HostListeningEvent {
+	address: string,
+	port: number
+}
+
+export interface HostPublishEvent {
+	channel: string,
+	data: unknown,
+	fanoutCount: number,
+	originWorkerId: string
+}
+
+export interface HostWorkerConnectEvent {
+	workerId: string
+}
+
+export interface HostWorkerDisconnectEvent {
+	workerId: string
+}
+
+interface WorkerConnection {
+	buffer: FrameDecoder,
+	socket: NetSocket,
+	subscriptions: Set<string>,
+	workerId: string
+}
+
+/**
+ * Broker relay that runs in the cluster "master" (or any dedicated broker
+ * process) and fans pub/sub traffic out across all connected worker
+ * processes. Each worker uses a `ClusterBroker` instance to connect to the
+ * host over a loopback TCP socket; publishes arrive on one connection and
+ * are forwarded to every other connection subscribed to the channel.
+ *
+ * The origin connection is intentionally skipped during fanout: a worker
+ * has already delivered its own publishes to local subscribers before
+ * forwarding them here, so echoing would cause duplicate delivery.
+ *
+ * Worker identity is tracked from the `hello` frame for diagnostics only;
+ * the host keys its subscription tables by connection object, so two
+ * workers can share a worker id (e.g. after a restart) without colliding.
+ */
+export class ClusterBrokerHost extends AsyncStreamEmitter<ClusterBrokerHostEvent> {
+	private readonly _channelSubscribers: Map<string, Set<WorkerConnection>>;
+	private readonly _codec: CodecEngine;
+	private readonly _options: ClusterBrokerHostOptions;
+	private _server: NetServer | null;
+	private readonly _workers: Set<WorkerConnection>;
+
+	constructor(options: ClusterBrokerHostOptions) {
+		super();
+
+		this._channelSubscribers = new Map();
+		this._codec = options.codecEngine ?? defaultCodec;
+		this._options = options;
+		this._server = null;
+		this._workers = new Set();
+	}
+
+	private cleanupWorker(worker: WorkerConnection): void {
+		if (!this._workers.delete(worker)) {
+			return;
+		}
+
+		for (const channel of worker.subscriptions) {
+			const set = this._channelSubscribers.get(channel);
+			if (set) {
+				set.delete(worker);
+				if (set.size === 0) {
+					this._channelSubscribers.delete(channel);
+				}
+			}
+		}
+
+		worker.subscriptions.clear();
+		this.emit('workerDisconnect', { workerId: worker.workerId });
+	}
+
+	close(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			if (!this._server) {
+				resolve();
+				return;
+			}
+
+			for (const worker of this._workers) {
+				worker.socket.destroy();
+			}
+
+			this._server.close((err) => {
+				this._server = null;
+				if (err) {
+					reject(err);
+					return;
+				}
+				resolve();
+			});
+		});
+	}
+
+	emit(event: 'error', data: HostErrorEvent): void;
+	emit(event: 'listening', data: HostListeningEvent): void;
+	emit(event: 'publish', data: HostPublishEvent): void;
+	emit(event: 'workerConnect', data: HostWorkerConnectEvent): void;
+	emit(event: 'workerDisconnect', data: HostWorkerDisconnectEvent): void;
+	emit(event: string, data: ClusterBrokerHostEvent): void {
+		super.emit(event, data);
+	}
+
+	private fanout(origin: WorkerConnection, message: PublishMessage): void {
+		const subscribers = this._channelSubscribers.get(message.channel);
+		let fanoutCount = 0;
+
+		if (subscribers) {
+			const frame = encodeFrame(this._codec, message);
+
+			for (const subscriber of subscribers) {
+				if (subscriber === origin) {
+					continue;
+				}
+				subscriber.socket.write(frame);
+				fanoutCount++;
+			}
+		}
+
+		this.emit('publish', {
+			channel: message.channel,
+			data: message.data,
+			fanoutCount,
+			originWorkerId: origin.workerId
+		});
+	}
+
+	listen(): DemuxedConsumableStream<StreamEvent<ClusterBrokerHostEvent>>;
+	listen(event: 'error'): DemuxedConsumableStream<HostErrorEvent>;
+	listen(event: 'listening'): DemuxedConsumableStream<HostListeningEvent>;
+	listen(event: 'publish'): DemuxedConsumableStream<HostPublishEvent>;
+	listen(event: 'workerConnect'): DemuxedConsumableStream<HostWorkerConnectEvent>;
+	listen(event: 'workerDisconnect'): DemuxedConsumableStream<HostWorkerDisconnectEvent>;
+	listen<U extends ClusterBrokerHostEvent, V = U>(event: string): DemuxedConsumableStream<V>;
+	listen<U extends ClusterBrokerHostEvent, V = U>(event?: string): DemuxedConsumableStream<V> {
+		return super.listen(event ?? '');
+	}
+
+	private onConnection(socket: NetSocket): void {
+		const worker: WorkerConnection = {
+			buffer: new FrameDecoder(this._codec),
+			socket,
+			subscriptions: new Set(),
+			workerId: `<unidentified:${socket.remoteAddress}:${socket.remotePort}>`
+		};
+
+		this._workers.add(worker);
+
+		socket.setNoDelay(true);
+
+		socket.on('data', (chunk: Buffer) => {
+			try {
+				const messages = worker.buffer.push(chunk);
+				for (const message of messages) {
+					this.onMessage(worker, message);
+				}
+			} catch (err) {
+				this.emit('error', { error: err as Error, workerId: worker.workerId });
+				worker.socket.destroy();
+			}
+		});
+
+		socket.on('error', (err) => {
+			this.emit('error', { error: err, workerId: worker.workerId });
+		});
+
+		socket.on('close', () => {
+			this.cleanupWorker(worker);
+		});
+	}
+
+	private onMessage(worker: WorkerConnection, message: WireMessage): void {
+		switch (message.type) {
+			case 'hello':
+				worker.workerId = message.workerId;
+				this.emit('workerConnect', { workerId: worker.workerId });
+				break;
+
+			case 'publish':
+				this.fanout(worker, message);
+				break;
+
+			case 'subscribe': {
+				if (worker.subscriptions.has(message.channel)) {
+					break;
+				}
+				worker.subscriptions.add(message.channel);
+				let set = this._channelSubscribers.get(message.channel);
+				if (!set) {
+					set = new Set();
+					this._channelSubscribers.set(message.channel, set);
+				}
+				set.add(worker);
+				break;
+			}
+
+			case 'unsubscribe':
+				this.removeSubscription(worker, message.channel);
+				break;
+		}
+	}
+
+	private removeSubscription(worker: WorkerConnection, channel: string): void {
+		if (!worker.subscriptions.delete(channel)) {
+			return;
+		}
+
+		const set = this._channelSubscribers.get(channel);
+
+		if (set) {
+			set.delete(worker);
+			if (set.size === 0) {
+				this._channelSubscribers.delete(channel);
+			}
+		}
+	}
+
+	start(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			if (this._server) {
+				resolve();
+				return;
+			}
+
+			const server = createServer((socket) => {
+				this.onConnection(socket);
+			});
+
+			server.on('error', (err) => {
+				this.emit('error', { error: err });
+				if (!server.listening) {
+					reject(err);
+				}
+			});
+
+			server.listen(this._options.port, this._options.host ?? '127.0.0.1', () => {
+				this._server = server;
+				const info = server.address() as AddressInfo | null;
+				this.emit('listening', {
+					address: info?.address ?? '127.0.0.1',
+					port: info?.port ?? this._options.port
+				});
+				resolve();
+			});
+		});
+	}
+
+	public get workerCount(): number {
+		return this._workers.size;
+	}
+}

--- a/packages/cluster-broker/src/cluster-broker-options.ts
+++ b/packages/cluster-broker/src/cluster-broker-options.ts
@@ -1,0 +1,41 @@
+import { CodecEngine } from '@socket-mesh/formatter';
+
+export interface ClusterBrokerHostOptions {
+	/** Codec used for wire frames. Defaults to the JSON codec. */
+	codecEngine?: CodecEngine,
+
+	/** Bind address for the TCP listener. Defaults to `127.0.0.1`. */
+	host?: string,
+
+	/** TCP port to listen on. Required. */
+	port: number
+}
+
+export interface ClusterBrokerOptions {
+	/**
+	 * Codec used to serialize wire frames. Defaults to the shared JSON
+	 * codec from `@socket-mesh/formatter` when omitted. Workers and host
+	 * must agree on the same codec.
+	 */
+	codecEngine?: CodecEngine,
+
+	/** Host ip/hostname of the broker process. Defaults to `127.0.0.1`. */
+	host?: string,
+
+	/** TCP port the broker host is listening on. */
+	port: number,
+
+	/**
+	 * Base delay between reconnect attempts when the underlying TCP
+	 * connection drops. The effective delay backs off exponentially up
+	 * to a 30s cap. Defaults to 200ms.
+	 */
+	reconnectBaseDelayMs?: number,
+
+	/**
+	 * Optional stable identifier for this worker. Used only for
+	 * diagnostics; the host identifies workers by connection, not by
+	 * this id. Defaults to `worker-<pid>`.
+	 */
+	workerId?: string
+}

--- a/packages/cluster-broker/src/cluster-broker.ts
+++ b/packages/cluster-broker/src/cluster-broker.ts
@@ -1,0 +1,273 @@
+import { ChannelMap, PublishOptions } from '@socket-mesh/channels';
+import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
+import { Broker, ExchangeClient, SimpleExchange } from '@socket-mesh/server/broker';
+import { connect, Socket as NetSocket } from 'net';
+
+import { ClusterBrokerOptions } from './cluster-broker-options.js';
+import { encodeFrame, FrameDecoder } from './frame-codec.js';
+import { WireMessage } from './wire.js';
+
+/**
+ * `Broker<T>` implementation that forwards publishes to a dedicated
+ * broker process over a loopback TCP socket and delivers received
+ * publishes to local exchange clients.
+ *
+ * Routing model
+ * -------------
+ * - Local subscribers (WebSocket clients attached to this worker) are
+ *   tracked in-process in `_clientSubscribers`, exactly like
+ *   `SimpleBroker`. They're delivered to synchronously on `publish`.
+ * - Whenever this worker acquires its FIRST local subscriber on a
+ *   channel, it sends a `subscribe` frame to the host so the host will
+ *   start forwarding publishes on that channel to this worker.
+ * - Whenever this worker drops its LAST local subscriber on a channel,
+ *   it sends an `unsubscribe` frame.
+ * - On local publish we deliver to local subscribers AND send a
+ *   `publish` frame to the host; the host fans out to other workers
+ *   subscribed to the channel and skips this origin connection, so
+ *   local delivery is not duplicated.
+ *
+ * Connection lifecycle
+ * --------------------
+ * - The initial `connect` happens in the constructor. The base `Broker`
+ *   marks `isReady = true` on the next tick regardless of the TCP link
+ *   state (so `Server` can finish its own bring-up immediately); the
+ *   actual TCP connect completes asynchronously in parallel.
+ * - If the TCP connection drops, the broker reconnects with exponential
+ *   backoff capped at 30s. On successful reconnect, all currently
+ *   tracked subscriptions are re-sent to the new host connection so the
+ *   worker resumes receiving messages without extra coordination.
+ * - Publishes issued while the socket is down are dropped for
+ *   cross-process delivery but still reach local subscribers. This
+ *   matches SimpleBroker semantics for in-process traffic and mirrors
+ *   how socket-cluster's SCBroker behaves during a host blip.
+ */
+
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+export class ClusterBroker<T extends ChannelMap> extends Broker<T> {
+	private readonly _clientSubscribers: { [channelName: string]: { [id: string]: ExchangeClient } };
+	private readonly _clientSubscribersCounter: { [channelName: string]: number };
+	private readonly _codec: CodecEngine;
+	private _destroyed: boolean;
+	private readonly _frameDecoder: FrameDecoder;
+	private readonly _options: ClusterBrokerOptions;
+	private _reconnectAttempt: number;
+	private _reconnectTimer: NodeJS.Timeout | null;
+	private _socket: NetSocket | null;
+	private readonly _workerId: string;
+	readonly exchange: SimpleExchange<T>;
+
+	constructor(options: ClusterBrokerOptions) {
+		super();
+
+		this._clientSubscribers = {};
+		this._clientSubscribersCounter = {};
+		this._codec = options.codecEngine ?? defaultCodec;
+		this._destroyed = false;
+		this._frameDecoder = new FrameDecoder(this._codec);
+		this._options = options;
+		this._reconnectAttempt = 0;
+		this._reconnectTimer = null;
+		this._socket = null;
+		this._workerId = options.workerId ?? `worker-${process.pid}`;
+
+		this.exchange = new SimpleExchange(this);
+
+		this.openConnection();
+	}
+
+	close(): Promise<void> {
+		return new Promise((resolve) => {
+			this._destroyed = true;
+
+			if (this._reconnectTimer) {
+				clearTimeout(this._reconnectTimer);
+				this._reconnectTimer = null;
+			}
+
+			if (!this._socket) {
+				resolve();
+				return;
+			}
+
+			this._socket.once('close', () => {
+				resolve();
+			});
+			this._socket.destroy();
+		});
+	}
+
+	private async deliverLocal(channelName: string, data: unknown): Promise<void> {
+		const packet: PublishOptions = { channel: channelName, data };
+		const subscribers = this._clientSubscribers[channelName] || {};
+		const work: Promise<void>[] = [];
+
+		for (const id in subscribers) {
+			work.push(subscribers[id]!.transmit('#publish', packet));
+		}
+
+		const result = await Promise.allSettled(work);
+
+		for (const item of result) {
+			if (item.status === 'rejected') {
+				this.emit('error', { error: item.reason as Error });
+			}
+		}
+	}
+
+	invokePublish<U extends keyof T & string>(channelName: U, data: T[U], suppressEvent?: boolean): Promise<void> {
+		return this.transmitPublish(channelName, data, suppressEvent);
+	}
+
+	isSubscribed(channelName: string): boolean {
+		return !!this._clientSubscribers[channelName];
+	}
+
+	private onIncomingMessage(message: WireMessage): void {
+		if (message.type !== 'publish') {
+			return;
+		}
+
+		void this.deliverLocal(message.channel, message.data);
+		this.emit('publish', { channel: message.channel, data: message.data as T[keyof T] });
+	}
+
+	private openConnection(): void {
+		if (this._destroyed) {
+			return;
+		}
+
+		const socket = connect({
+			host: this._options.host ?? '127.0.0.1',
+			port: this._options.port
+		});
+
+		socket.setNoDelay(true);
+
+		this._socket = socket;
+
+		socket.on('connect', () => {
+			this._reconnectAttempt = 0;
+
+			this.send({ type: 'hello', workerId: this._workerId });
+
+			// Re-subscribe after a reconnect so the host forwards on the
+			// channels we still care about locally.
+			for (const channel of Object.keys(this._clientSubscribers)) {
+				this.send({ channel, type: 'subscribe' });
+			}
+		});
+
+		socket.on('data', (chunk: Buffer) => {
+			try {
+				const messages = this._frameDecoder.push(chunk);
+				for (const message of messages) {
+					this.onIncomingMessage(message);
+				}
+			} catch (err) {
+				this.emit('error', { error: err as Error });
+				socket.destroy();
+			}
+		});
+
+		socket.on('error', (err) => {
+			this.emit('error', { error: err });
+		});
+
+		socket.on('close', () => {
+			this._socket = null;
+			if (!this._destroyed) {
+				this.scheduleReconnect();
+			}
+		});
+	}
+
+	private scheduleReconnect(): void {
+		if (this._reconnectTimer) {
+			return;
+		}
+
+		const base = this._options.reconnectBaseDelayMs ?? 200;
+		const delay = Math.min(
+			base * Math.pow(2, this._reconnectAttempt),
+			MAX_RECONNECT_DELAY_MS
+		);
+
+		this._reconnectAttempt++;
+
+		this._reconnectTimer = setTimeout(() => {
+			this._reconnectTimer = null;
+			this.openConnection();
+		}, delay);
+	}
+
+	private send(message: WireMessage): void {
+		if (!this._socket || this._socket.destroyed || !this._socket.writable) {
+			return;
+		}
+
+		try {
+			const frame = encodeFrame(this._codec, message);
+			this._socket.write(frame);
+		} catch (err) {
+			this.emit('error', { error: err as Error });
+		}
+	}
+
+	async subscribe(client: ExchangeClient, channelName: string): Promise<void> {
+		let shouldForward = false;
+
+		if (!this._clientSubscribers[channelName]) {
+			this._clientSubscribers[channelName] = {};
+			this._clientSubscribersCounter[channelName] = 0;
+			this.emit('subscribe', { channel: channelName });
+			shouldForward = true;
+		}
+
+		if (!this._clientSubscribers[channelName][client.id]) {
+			this._clientSubscribersCounter[channelName]!++;
+		}
+		this._clientSubscribers[channelName][client.id] = client;
+
+		if (shouldForward) {
+			this.send({ channel: channelName, type: 'subscribe' });
+		}
+	}
+
+	subscriptions(): string[] {
+		return Object.keys(this._clientSubscribers);
+	}
+
+	async transmitPublish<U extends keyof T & string>(channelName: U, data: T[U], suppressEvent?: boolean): Promise<void> {
+		await this.deliverLocal(channelName, data);
+		this.send({ channel: channelName, data, type: 'publish' });
+
+		if (!suppressEvent) {
+			this.emit('publish', { channel: channelName, data });
+		}
+	}
+
+	async unsubscribe(client: ExchangeClient, channelName: string): Promise<void> {
+		if (!this._clientSubscribers[channelName]) {
+			return;
+		}
+		if (!this._clientSubscribers[channelName][client.id]) {
+			return;
+		}
+
+		this._clientSubscribersCounter[channelName]!--;
+		delete this._clientSubscribers[channelName][client.id];
+
+		if (this._clientSubscribersCounter[channelName]! <= 0) {
+			delete this._clientSubscribers[channelName];
+			delete this._clientSubscribersCounter[channelName];
+			this.emit('unsubscribe', { channel: channelName });
+			this.send({ channel: channelName, type: 'unsubscribe' });
+		}
+	}
+
+	public get workerId(): string {
+		return this._workerId;
+	}
+}

--- a/packages/cluster-broker/src/frame-codec.ts
+++ b/packages/cluster-broker/src/frame-codec.ts
@@ -1,0 +1,77 @@
+import { CodecEngine } from '@socket-mesh/formatter';
+
+import { WireMessage } from './wire.js';
+
+/**
+ * Length-prefixed framing for wire messages over a stream socket. Each
+ * frame is `<4-byte big-endian length><utf-8 payload>` where the payload
+ * is the codec-encoded wire message.
+ *
+ * The buffered decoder tolerates fragmented reads (a single `data`
+ * event from node's `net` may contain a partial frame, multiple frames,
+ * or both). It accumulates bytes until at least one full frame is
+ * available and then drains as many complete frames as possible,
+ * yielding each decoded message to the caller.
+ */
+
+const LENGTH_PREFIX_BYTES = 4;
+const MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
+export function encodeFrame(codec: CodecEngine, message: WireMessage): Buffer {
+	const payload = Buffer.from(codec.encode(message), 'utf8');
+
+	if (payload.length > MAX_FRAME_BYTES) {
+		throw new Error(
+			`cluster-broker frame exceeds max size (${payload.length} > ${MAX_FRAME_BYTES} bytes)`
+		);
+	}
+
+	const frame = Buffer.allocUnsafe(LENGTH_PREFIX_BYTES + payload.length);
+
+	frame.writeUInt32BE(payload.length, 0);
+	payload.copy(frame, LENGTH_PREFIX_BYTES);
+
+	return frame;
+}
+
+export class FrameDecoder {
+	private _buffer: Buffer;
+	private readonly _codec: CodecEngine;
+
+	constructor(codec: CodecEngine) {
+		this._codec = codec;
+		this._buffer = Buffer.alloc(0);
+	}
+
+	push(chunk: Buffer): WireMessage[] {
+		this._buffer = this._buffer.length === 0
+			? chunk
+			: Buffer.concat([this._buffer, chunk]);
+
+		const messages: WireMessage[] = [];
+
+		while (this._buffer.length >= LENGTH_PREFIX_BYTES) {
+			const frameLength = this._buffer.readUInt32BE(0);
+
+			if (frameLength > MAX_FRAME_BYTES) {
+				throw new Error(
+					`cluster-broker frame exceeds max size (${frameLength} > ${MAX_FRAME_BYTES} bytes)`
+				);
+			}
+
+			const frameEnd = LENGTH_PREFIX_BYTES + frameLength;
+
+			if (this._buffer.length < frameEnd) {
+				break;
+			}
+
+			const payload = this._buffer.subarray(LENGTH_PREFIX_BYTES, frameEnd).toString('utf8');
+
+			this._buffer = this._buffer.subarray(frameEnd);
+
+			messages.push(this._codec.decode(payload) as WireMessage);
+		}
+
+		return messages;
+	}
+}

--- a/packages/cluster-broker/src/index.ts
+++ b/packages/cluster-broker/src/index.ts
@@ -1,0 +1,4 @@
+export * from './cluster-broker-host.js';
+export * from './cluster-broker-options.js';
+export * from './cluster-broker.js';
+export * from './wire.js';

--- a/packages/cluster-broker/src/wire.ts
+++ b/packages/cluster-broker/src/wire.ts
@@ -1,0 +1,49 @@
+/**
+ * Wire protocol for cluster-broker traffic between workers and the broker
+ * host. Every message is serialized as JSON by a CodecEngine, framed with a
+ * 4-byte big-endian length prefix, and sent over a plain TCP connection on
+ * loopback.
+ *
+ * The protocol is intentionally tiny:
+ *
+ * - `hello`        - worker greets the host and gives itself a stable id so
+ *                    the host can log and disambiguate reconnects.
+ * - `subscribe`    - worker registers interest in a channel. The host will
+ *                    from then on forward publishes on that channel to this
+ *                    worker (but skip the originating worker, see below).
+ * - `unsubscribe`  - worker drops interest in a channel.
+ * - `publish`      - either direction. Worker -> host means "fan this out";
+ *                    host -> worker means "here is a message you are
+ *                    subscribed to". The host uses the TCP connection the
+ *                    publish arrived on as the origin and does NOT echo the
+ *                    publish back to that connection, because the worker has
+ *                    already delivered the message to its own local
+ *                    subscribers before it forwarded it.
+ */
+
+export interface HelloMessage {
+	type: 'hello',
+	workerId: string
+}
+
+export interface PublishMessage {
+	channel: string,
+	data: unknown,
+	type: 'publish'
+}
+
+export interface SubscribeMessage {
+	channel: string,
+	type: 'subscribe'
+}
+
+export interface UnsubscribeMessage {
+	channel: string,
+	type: 'unsubscribe'
+}
+
+export type WireMessage =
+	| HelloMessage
+	| PublishMessage
+	| SubscribeMessage
+	| UnsubscribeMessage;

--- a/packages/cluster-broker/test/cluster-broker.spec.ts
+++ b/packages/cluster-broker/test/cluster-broker.spec.ts
@@ -1,3 +1,4 @@
+import { ChannelMap } from '@socket-mesh/channels';
 import { ExchangeClient } from '@socket-mesh/server/broker';
 import assert from 'node:assert';
 import { AddressInfo, createServer } from 'node:net';
@@ -5,7 +6,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { ClusterBroker, ClusterBrokerHost } from '../src/index.js';
 
-interface Channels {
+interface Channels extends ChannelMap {
 	bar: { value: number },
 	foo: string
 }

--- a/packages/cluster-broker/test/cluster-broker.spec.ts
+++ b/packages/cluster-broker/test/cluster-broker.spec.ts
@@ -1,0 +1,195 @@
+import { ExchangeClient } from '@socket-mesh/server/broker';
+import assert from 'node:assert';
+import { AddressInfo, createServer } from 'node:net';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { ClusterBroker, ClusterBrokerHost } from '../src/index.js';
+
+interface Channels {
+	bar: { value: number },
+	foo: string
+}
+
+/**
+ * Utility: a minimal `ExchangeClient` that records every `#publish`
+ * transmit so tests can assert on the payloads delivered locally.
+ */
+function makeClient(id: string): ExchangeClient & { received: Array<{ channel: string, data: unknown }> } {
+	const received: Array<{ channel: string, data: unknown }> = [];
+
+	return {
+		id,
+		received,
+		async transmit(_event, packet) {
+			received.push({ channel: packet.channel, data: packet.data });
+		}
+	};
+}
+
+/**
+ * Pick an ephemeral port from the OS by briefly listening on :0. The
+ * returned port is released before we hand it back so the test can bind
+ * the real broker host there.
+ */
+async function pickEphemeralPort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.unref();
+		server.on('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address() as AddressInfo | null;
+			const port = address?.port;
+			server.close(() => {
+				if (port === undefined) {
+					reject(new Error('failed to pick ephemeral port'));
+					return;
+				}
+				resolve(port);
+			});
+		});
+	});
+}
+
+function wait(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('ClusterBroker', () => {
+	let host: ClusterBrokerHost;
+	let port: number;
+
+	beforeEach(async () => {
+		port = await pickEphemeralPort();
+		host = new ClusterBrokerHost({ port });
+		await host.start();
+	});
+
+	afterEach(async () => {
+		await host.close();
+	});
+
+	it('delivers local publishes synchronously without going through the host', async () => {
+		const broker = new ClusterBroker<Channels>({ port });
+
+		try {
+			const subscriber = makeClient('local-sub');
+			await broker.subscribe(subscriber, 'foo');
+
+			await broker.transmitPublish('foo', 'hello');
+
+			assert.deepStrictEqual(subscriber.received, [
+				{ channel: 'foo', data: 'hello' }
+			]);
+		} finally {
+			await broker.close();
+		}
+	});
+
+	it('fans out publishes from one worker to another subscribed worker', async () => {
+		const workerA = new ClusterBroker<Channels>({ port, workerId: 'worker-a' });
+		const workerB = new ClusterBroker<Channels>({ port, workerId: 'worker-b' });
+
+		try {
+			// Wait for both TCP connections to come up. The host reports
+			// workerConnect via listen('workerConnect'), but using a
+			// short wait here keeps the test readable.
+			await wait(75);
+
+			const subscriberB = makeClient('b-sub');
+			await workerB.subscribe(subscriberB, 'foo');
+
+			// Give the subscribe frame time to reach the host and be
+			// registered in the channel table.
+			await wait(50);
+
+			await workerA.transmitPublish('foo', 'crosses-the-wire');
+
+			await wait(50);
+
+			assert.deepStrictEqual(subscriberB.received, [
+				{ channel: 'foo', data: 'crosses-the-wire' }
+			]);
+		} finally {
+			await workerA.close();
+			await workerB.close();
+		}
+	});
+
+	it('does not echo a worker\'s publish back to its own subscribers via the host', async () => {
+		// Both workers subscribe to the same channel. Worker A publishes;
+		// subscriber A should see exactly one delivery (the local one),
+		// NOT a second delivery bounced through the host.
+		const workerA = new ClusterBroker<Channels>({ port, workerId: 'worker-a' });
+		const workerB = new ClusterBroker<Channels>({ port, workerId: 'worker-b' });
+
+		try {
+			await wait(75);
+
+			const subscriberA = makeClient('a-sub');
+			const subscriberB = makeClient('b-sub');
+
+			await workerA.subscribe(subscriberA, 'bar');
+			await workerB.subscribe(subscriberB, 'bar');
+
+			await wait(50);
+
+			await workerA.transmitPublish('bar', { value: 42 });
+
+			await wait(50);
+
+			assert.strictEqual(subscriberA.received.length, 1, 'no self-echo');
+			assert.deepStrictEqual(subscriberA.received[0], { channel: 'bar', data: { value: 42 } });
+
+			assert.strictEqual(subscriberB.received.length, 1, 'remote delivery');
+			assert.deepStrictEqual(subscriberB.received[0], { channel: 'bar', data: { value: 42 } });
+		} finally {
+			await workerA.close();
+			await workerB.close();
+		}
+	});
+
+	it('stops forwarding to a worker after it unsubscribes', async () => {
+		const workerA = new ClusterBroker<Channels>({ port });
+		const workerB = new ClusterBroker<Channels>({ port });
+
+		try {
+			await wait(75);
+
+			const subscriberB = makeClient('b-sub');
+			await workerB.subscribe(subscriberB, 'foo');
+			await wait(50);
+
+			await workerA.transmitPublish('foo', 'first');
+			await wait(50);
+
+			await workerB.unsubscribe(subscriberB, 'foo');
+			await wait(50);
+
+			await workerA.transmitPublish('foo', 'second');
+			await wait(50);
+
+			assert.deepStrictEqual(subscriberB.received, [
+				{ channel: 'foo', data: 'first' }
+			]);
+		} finally {
+			await workerA.close();
+			await workerB.close();
+		}
+	});
+
+	it('tracks connected workers on the host', async () => {
+		const workerA = new ClusterBroker<Channels>({ port });
+		const workerB = new ClusterBroker<Channels>({ port });
+
+		try {
+			await wait(75);
+			assert.strictEqual(host.workerCount, 2);
+		} finally {
+			await workerA.close();
+			await workerB.close();
+		}
+
+		await wait(50);
+		assert.strictEqual(host.workerCount, 0);
+	});
+});

--- a/packages/cluster-broker/tsconfig.build.json
+++ b/packages/cluster-broker/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@socket-mesh/typescript-config/tsconfig.build.json",
+	"include": ["src"],
+	"compilerOptions": {
+		"module": "Node16",
+		"outDir": "dist"
+	}
+}

--- a/packages/cluster-broker/tsconfig.json
+++ b/packages/cluster-broker/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "@socket-mesh/typescript-config/tsconfig.json"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@socket-mesh/core",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Core module for SocketMesh Server",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/src/socket-transport.ts
+++ b/packages/core/src/socket-transport.ts
@@ -96,7 +96,6 @@ export class BaseSocketTransport<TState extends object = {}> {
 	private _authToken: AuthToken | null;
 	private readonly _callbackMap: { [cid: number]: InvokeCallback<unknown> };
 	private readonly _callIdGenerator: CallIdGenerator;
-	private readonly _handlers: LooseHandlerMap;
 	private _inboundProcessedMessageCount: number;
 	private _inboundReceivedMessageCount: number;
 	private _isReady: boolean;
@@ -130,7 +129,6 @@ export class BaseSocketTransport<TState extends object = {}> {
 
 		this._callbackMap = {};
 		this.codecEngine = options?.codecEngine || defaultCodec;
-		this._handlers = options?.handlers || {};
 		this.id = null;
 		this._inboundProcessedMessageCount = 0;
 		this._inboundReceivedMessageCount = 0;
@@ -138,6 +136,19 @@ export class BaseSocketTransport<TState extends object = {}> {
 		this._outboundSentMessageCount = 0;
 		this._pingTimeoutRef = null;
 		this._serviceHandlers = options?.serviceHandlers || {};
+
+		// Flat (non-service) handlers live under the empty-string service key
+		// so dispatch only has to consult one map. We merge `options.handlers`
+		// into that slot without cloning the top-level map, so dynamic mutations
+		// to the caller's serviceHandlers reference (e.g. Server.addHandlers)
+		// still propagate to this transport.
+		if (options?.handlers) {
+			this._serviceHandlers[''] = {
+				...this._serviceHandlers[''],
+				...options.handlers
+			};
+		}
+
 		this.plugins = options?.plugins || [];
 		this.streamCleanupMode = options?.streamCleanupMode || 'kill';
 	}
@@ -496,10 +507,8 @@ export class BaseSocketTransport<TState extends object = {}> {
 				response = { error: pluginError, rid: packet.cid, timeoutAt };
 			}
 		} else {
-			const service = 'service' in packet ? packet.service : undefined;
-			const handler = service
-				? this._serviceHandlers[service]?.[packet.method]
-				: this._handlers[packet.method];
+			const service = 'service' in packet ? packet.service : '';
+			const handler = this._serviceHandlers[service]?.[packet.method];
 
 			if (handler) {
 				wasHandled = true;

--- a/packages/core/src/socket-transport.ts
+++ b/packages/core/src/socket-transport.ts
@@ -103,6 +103,7 @@ export class BaseSocketTransport<TState extends object = {}> {
 	private _outboundPreparedMessageCount: number;
 	private _outboundSentMessageCount: number;
 	private _pingTimeoutRef: NodeJS.Timeout | null;
+	private readonly _serviceHandlers: { [service: string]: LooseHandlerMap };
 	private _signedAuthToken: null | SignedAuthToken;
 	private _socket!: BaseSocket<TState>;
 	private _webSocket: null | ws.WebSocket;
@@ -136,6 +137,7 @@ export class BaseSocketTransport<TState extends object = {}> {
 		this._outboundPreparedMessageCount = 0;
 		this._outboundSentMessageCount = 0;
 		this._pingTimeoutRef = null;
+		this._serviceHandlers = options?.serviceHandlers || {};
 		this.plugins = options?.plugins || [];
 		this.streamCleanupMode = options?.streamCleanupMode || 'kill';
 	}
@@ -494,7 +496,10 @@ export class BaseSocketTransport<TState extends object = {}> {
 				response = { error: pluginError, rid: packet.cid, timeoutAt };
 			}
 		} else {
-			const handler = this._handlers[packet.method];
+			const service = 'service' in packet ? packet.service : undefined;
+			const handler = service
+				? this._serviceHandlers[service]?.[packet.method]
+				: this._handlers[packet.method];
 
 			if (handler) {
 				wasHandled = true;

--- a/packages/core/src/socket.ts
+++ b/packages/core/src/socket.ts
@@ -25,6 +25,7 @@ export interface BaseSocketOptions<TState extends object = {}> {
 	handlers?: LooseHandlerMap,
 	isPingTimeoutDisabled?: boolean,
 	plugins?: AnyPlugin[],
+	serviceHandlers?: { [service: string]: LooseHandlerMap },
 	state?: Partial<TState>,
 
 	// Lets you specify the default cleanup behaviour for

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@socket-mesh/server",
 	"description": "A TCP socket pair for easily transmitting full messages without worrying about request size limits.",
-	"version": "19.0.0",
+	"version": "19.1.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/server/src/server-options.ts
+++ b/packages/server/src/server-options.ts
@@ -60,6 +60,19 @@ export interface ServerOptions<
 
 	plugins?: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[],
 
+	// Handler groups keyed by service name. Each key must match a service
+	// declared in TService and the handlers are strongly-typed against that
+	// service's method map. Services can also be added/removed dynamically
+	// at runtime via Server.addHandlers()/removeHandlers().
+	serviceHandlers?: {
+		[TServiceName in keyof TService & string]?: HandlerMap<
+			TService[TServiceName],
+			TState & ServerSocketState,
+			ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+			ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+		>
+	},
+
 	// The maximum number of unique channels which a single socket can subscribe to.
 	socketChannelLimit?: number,
 

--- a/packages/server/src/server-socket.ts
+++ b/packages/server/src/server-socket.ts
@@ -3,7 +3,7 @@ import { ClientPrivateMap, ServerPrivateMap } from '@socket-mesh/client';
 import {
 	AuthenticateEvent, AuthStateChangeEvent, BadAuthTokenEvent, BaseSocket, BaseSocketOptions,
 	CloseEvent, ConnectEvent, ConnectingEvent, DeauthenticateEvent, DisconnectEvent, ErrorEvent,
-	FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, LooseHandlerMap, MessageEvent,
+	FunctionReturnType, InvokeMethodOptions, InvokeServiceOptions, MessageEvent,
 	PingEvent, PongEvent, PrivateMethodMap, PublicMethodMap, RemoveAuthTokenEvent, RequestEvent,
 	ResponseEvent, ServiceMap, ServiceMethodName, ServiceName, Socket, SocketEvent, toError,
 	TypedRequestEvent, TypedResponseEvent, TypedSocketEvent
@@ -28,7 +28,6 @@ export interface ServerSocketOptions<
 	TPrivateOutgoing extends PrivateMethodMap,
 	TServerState extends object
 > extends BaseSocketOptions<TState & ServerSocketState> {
-	handlers: LooseHandlerMap,
 	id?: string,
 	plugins?: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[],
 	request: IncomingMessage,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,7 @@
 import { AsyncStreamEmitter } from '@socket-mesh/async-stream-emitter';
 import { AuthEngine, defaultAuthEngine, isAuthEngine } from '@socket-mesh/auth-engine';
 import { ChannelMap } from '@socket-mesh/channels';
-import { removeAuthTokenHandler } from '@socket-mesh/client';
+import { removeAuthTokenHandler, ServerPrivateMap } from '@socket-mesh/client';
 import { CallIdGenerator, HandlerMap, LooseHandlerMap, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode, toError } from '@socket-mesh/core';
 import { ServerProtocolError } from '@socket-mesh/errors';
 import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
@@ -35,11 +35,11 @@ export class Server<
 	TServerState extends object = {}
 > extends AsyncStreamEmitter<ServerEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>> {
 	private readonly _callIdGenerator: CallIdGenerator;
+	private readonly _handlers: { [service: string]: LooseHandlerMap };
 
 	private _isListening: boolean;
 	private _isReady: boolean;
 	private _pingIntervalRef: NodeJS.Timeout | null;
-	private readonly _serviceHandlers: { [service: string]: LooseHandlerMap };
 	private readonly _wss: WebSocketServer;
 
 	// | ServerSocket<TIncomingMap, TServiceMap, TOutgoingMap, TPrivateIncomingMap, TPrivateOutgoingMap, TServerState, TSocketState>
@@ -92,7 +92,7 @@ export class Server<
 
 		// Flat handlers live under the empty-string service key so dispatch
 		// (and Server.addHandlers/removeHandlers) only has to consult one map.
-		this._serviceHandlers = {
+		this._handlers = {
 			'': Object.assign(
 				{
 					'#authenticate': authenticateHandler,
@@ -108,7 +108,7 @@ export class Server<
 
 		if (options.serviceHandlers) {
 			for (const service of Object.keys(options.serviceHandlers)) {
-				this._serviceHandlers[service] = { ...options.serviceHandlers[service] };
+				this._handlers[service] = { ...options.serviceHandlers[service] };
 			}
 		}
 
@@ -158,18 +158,28 @@ export class Server<
 	}
 
 	/**
-	 * Register a group of strongly-typed request handlers under a service name.
+	 * Register a group of strongly-typed request handlers.
 	 *
 	 * Handlers added this way can be added or replaced after the server has
 	 * started and are immediately visible to all existing and future
-	 * connections (the underlying handler map is shared by reference). The
-	 * service name is surfaced via {@link services} so UI/tooling can list
-	 * which groups are currently installed.
+	 * connections (the underlying handler map is shared by reference).
 	 *
-	 * When the service name is known to the server's `TService` generic,
-	 * TypeScript validates the handler shape against the declared method map.
-	 * For ad-hoc/dynamic services not present in `TService`, pass an explicit
-	 * generic argument with the method map for the new service.
+	 * When called with a service name, the handlers are grouped under that
+	 * service and surfaced via {@link services} so UI/tooling can list which
+	 * groups are currently installed. When the service name is known to the
+	 * server's `TService` generic, TypeScript validates the handler shape
+	 * against the declared method map. For ad-hoc/dynamic services not
+	 * present in `TService`, pass an explicit generic argument with the
+	 * method map for the new service.
+	 *
+	 * When called without a service name, the handlers are registered as
+	 * flat (top-level) handlers routed by method name alone — the same
+	 * surface as `options.handlers` on the server constructor. These do not
+	 * appear in {@link services}.
+	 *
+	 * @example
+	 * // Flat handlers (no service name):
+	 * server.addHandlers({ doThing: async (args) => { ... } });
 	 *
 	 * @example
 	 * // Statically declared on the server generic:
@@ -179,6 +189,14 @@ export class Server<
 	 * // Dynamically added from a module at runtime:
 	 * server.addHandlers<'inventory', InventoryMethodMap>('inventory', handlers);
 	 */
+	public addHandlers(
+		handlers: HandlerMap<
+			TIncoming & TPrivateIncoming & ServerPrivateMap,
+			TState & ServerSocketState,
+			ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+			ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+		>
+	): void;
 	public addHandlers<
 		TServiceName extends keyof TService & string
 	>(
@@ -202,12 +220,18 @@ export class Server<
 			ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
 		>
 	): void;
-	public addHandlers(service: string, handlers: LooseHandlerMap): void {
-		if (!this._serviceHandlers[service]) {
-			this._serviceHandlers[service] = {};
+	public addHandlers(
+		serviceOrHandlers: LooseHandlerMap | string,
+		handlers?: LooseHandlerMap
+	): void {
+		const service = typeof serviceOrHandlers === 'string' ? serviceOrHandlers : '';
+		const map = typeof serviceOrHandlers === 'string' ? handlers! : serviceOrHandlers;
+
+		if (!this._handlers[service]) {
+			this._handlers[service] = {};
 		}
 
-		Object.assign(this._serviceHandlers[service], handlers);
+		Object.assign(this._handlers[service], map);
 	}
 
 	public addPlugin(...plugin: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[]): void {
@@ -334,7 +358,7 @@ export class Server<
 			return [];
 		}
 
-		const group = this._serviceHandlers[service];
+		const group = this._handlers[service];
 		return group ? Object.keys(group) : [];
 	}
 
@@ -399,7 +423,7 @@ export class Server<
 			plugins: this.plugins,
 			request: upgradeReq,
 			server: this,
-			serviceHandlers: this._serviceHandlers,
+			serviceHandlers: this._handlers,
 			socket: wsSocket,
 			state: {} as any,
 			streamCleanupMode: this.socketStreamCleanupMode
@@ -438,27 +462,48 @@ export class Server<
 	 * Unregister either a whole service (when `methods` is omitted) or a
 	 * specific set of methods within a service. Removing a service empties
 	 * the group and drops the key so it no longer appears in {@link services}.
+	 *
+	 * Call with an array of method names (no service) to remove flat
+	 * (top-level) handlers by name. The flat slot itself is never dropped
+	 * because it holds the built-in protocol handlers.
 	 */
-	public removeHandlers(service: string, methods?: readonly string[] | string): void {
-		const group = this._serviceHandlers[service];
+	public removeHandlers(methods: readonly string[]): void;
+	public removeHandlers(service: string, methods?: readonly string[] | string): void;
+	public removeHandlers(
+		serviceOrMethods: readonly string[] | string,
+		methods?: readonly string[] | string
+	): void {
+		let service: string;
+		let list: readonly string[] | undefined;
+
+		if (Array.isArray(serviceOrMethods)) {
+			service = '';
+			list = serviceOrMethods;
+		} else {
+			service = serviceOrMethods as string;
+			list = typeof methods === 'string' ? [methods] : methods;
+		}
+
+		const group = this._handlers[service];
 
 		if (!group) {
 			return;
 		}
 
-		if (methods === undefined) {
-			delete this._serviceHandlers[service];
+		if (list === undefined) {
+			// Never drop the flat slot — it holds built-in protocol handlers.
+			if (service !== '') {
+				delete this._handlers[service];
+			}
 			return;
 		}
-
-		const list = typeof methods === 'string' ? [methods] : methods;
 
 		for (const method of list) {
 			delete group[method];
 		}
 
-		if (Object.keys(group).length === 0) {
-			delete this._serviceHandlers[service];
+		if (service !== '' && Object.keys(group).length === 0) {
+			delete this._handlers[service];
 		}
 	}
 
@@ -466,7 +511,7 @@ export class Server<
 	public get services(): string[] {
 		// The empty-string slot holds flat (non-service) handlers internally
 		// and is not part of the public service surface.
-		return Object.keys(this._serviceHandlers).filter(service => service !== '');
+		return Object.keys(this._handlers).filter(service => service !== '');
 	}
 
 	private socketDisconnected(

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -35,7 +35,6 @@ export class Server<
 	TServerState extends object = {}
 > extends AsyncStreamEmitter<ServerEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>> {
 	private readonly _callIdGenerator: CallIdGenerator;
-	private readonly _handlers: LooseHandlerMap;
 
 	private _isListening: boolean;
 	private _isReady: boolean;
@@ -91,18 +90,21 @@ export class Server<
 		this.clientCount = 0;
 		this.codecEngine = options.codecEngine || defaultCodec;
 
-		this._handlers = Object.assign(
-			{
-				'#authenticate': authenticateHandler,
-				'#handshake': handshakeHandler,
-				'#publish': publishHandler,
-				'#removeAuthToken': removeAuthTokenHandler,
-				'#subscribe': subscribeHandler,
-				'#unsubscribe': unsubscribeHandler
-			},
-			options.handlers
-		);
-		this._serviceHandlers = {};
+		// Flat handlers live under the empty-string service key so dispatch
+		// (and Server.addHandlers/removeHandlers) only has to consult one map.
+		this._serviceHandlers = {
+			'': Object.assign(
+				{
+					'#authenticate': authenticateHandler,
+					'#handshake': handshakeHandler,
+					'#publish': publishHandler,
+					'#removeAuthToken': removeAuthTokenHandler,
+					'#subscribe': subscribeHandler,
+					'#unsubscribe': unsubscribeHandler
+				},
+				options.handlers
+			)
+		};
 
 		if (options.serviceHandlers) {
 			for (const service of Object.keys(options.serviceHandlers)) {
@@ -326,6 +328,12 @@ export class Server<
 
 	/** Method names registered under a given service, or an empty array if none. */
 	public getServiceMethods(service: string): string[] {
+		if (service === '') {
+			// The empty-string slot stores flat (non-service) handlers internally
+			// and is not part of the public service surface.
+			return [];
+		}
+
 		const group = this._serviceHandlers[service];
 		return group ? Object.keys(group) : [];
 	}
@@ -388,7 +396,6 @@ export class Server<
 			ackTimeoutMs: this.ackTimeoutMs,
 			callIdGenerator: this._callIdGenerator,
 			codecEngine: this.codecEngine,
-			handlers: this._handlers,
 			plugins: this.plugins,
 			request: upgradeReq,
 			server: this,
@@ -457,7 +464,9 @@ export class Server<
 
 	/** Names of all service handler groups currently registered on the server. */
 	public get services(): string[] {
-		return Object.keys(this._serviceHandlers);
+		// The empty-string slot holds flat (non-service) handlers internally
+		// and is not part of the public service surface.
+		return Object.keys(this._serviceHandlers).filter(service => service !== '');
 	}
 
 	private socketDisconnected(

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,7 +2,7 @@ import { AsyncStreamEmitter } from '@socket-mesh/async-stream-emitter';
 import { AuthEngine, defaultAuthEngine, isAuthEngine } from '@socket-mesh/auth-engine';
 import { ChannelMap } from '@socket-mesh/channels';
 import { removeAuthTokenHandler } from '@socket-mesh/client';
-import { CallIdGenerator, LooseHandlerMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode, toError } from '@socket-mesh/core';
+import { CallIdGenerator, HandlerMap, LooseHandlerMap, MethodMap, PrivateMethodMap, PublicMethodMap, ServiceMap, StreamCleanupMode, toError } from '@socket-mesh/core';
 import { ServerProtocolError } from '@socket-mesh/errors';
 import defaultCodec, { CodecEngine } from '@socket-mesh/formatter';
 import { DemuxedConsumableStream, StreamEvent } from '@socket-mesh/stream-demux';
@@ -20,7 +20,9 @@ import { subscribeHandler } from './handlers/subscribe.js';
 import { unsubscribeHandler } from './handlers/unsubscribe.js';
 import { ServerPlugin } from './plugin/server-plugin.js';
 import { ServerOptions } from './server-options.js';
+import { ServerSocketState } from './server-socket-state.js';
 import { ServerSocket } from './server-socket.js';
+import { ServerTransport } from './server-transport.js';
 
 export class Server<
 	TIncoming extends PublicMethodMap = {},
@@ -33,11 +35,12 @@ export class Server<
 	TServerState extends object = {}
 > extends AsyncStreamEmitter<ServerEvent<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>> {
 	private readonly _callIdGenerator: CallIdGenerator;
-	private _handlers: LooseHandlerMap;
+	private readonly _handlers: LooseHandlerMap;
 
 	private _isListening: boolean;
 	private _isReady: boolean;
 	private _pingIntervalRef: NodeJS.Timeout | null;
+	private readonly _serviceHandlers: { [service: string]: LooseHandlerMap };
 	private readonly _wss: WebSocketServer;
 
 	// | ServerSocket<TIncomingMap, TServiceMap, TOutgoingMap, TPrivateIncomingMap, TPrivateOutgoingMap, TServerState, TSocketState>
@@ -99,6 +102,14 @@ export class Server<
 			},
 			options.handlers
 		);
+		this._serviceHandlers = {};
+
+		if (options.serviceHandlers) {
+			for (const service of Object.keys(options.serviceHandlers)) {
+				this._serviceHandlers[service] = { ...options.serviceHandlers[service] };
+			}
+		}
+
 		this.httpServer = options.server!;
 
 		this.plugins = options.plugins || [];
@@ -142,6 +153,59 @@ export class Server<
 				this.emit('ready', {});
 			})();
 		}
+	}
+
+	/**
+	 * Register a group of strongly-typed request handlers under a service name.
+	 *
+	 * Handlers added this way can be added or replaced after the server has
+	 * started and are immediately visible to all existing and future
+	 * connections (the underlying handler map is shared by reference). The
+	 * service name is surfaced via {@link services} so UI/tooling can list
+	 * which groups are currently installed.
+	 *
+	 * When the service name is known to the server's `TService` generic,
+	 * TypeScript validates the handler shape against the declared method map.
+	 * For ad-hoc/dynamic services not present in `TService`, pass an explicit
+	 * generic argument with the method map for the new service.
+	 *
+	 * @example
+	 * // Statically declared on the server generic:
+	 * server.addHandlers('account', { find: async (args) => { ... } });
+	 *
+	 * @example
+	 * // Dynamically added from a module at runtime:
+	 * server.addHandlers<'inventory', InventoryMethodMap>('inventory', handlers);
+	 */
+	public addHandlers<
+		TServiceName extends keyof TService & string
+	>(
+		service: TServiceName,
+		handlers: HandlerMap<
+			TService[TServiceName],
+			TState & ServerSocketState,
+			ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+			ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+		>
+	): void;
+	public addHandlers<
+		TServiceName extends string,
+		TServiceMethodMap extends MethodMap
+	>(
+		service: TServiceName,
+		handlers: HandlerMap<
+			TServiceMethodMap,
+			TState & ServerSocketState,
+			ServerSocket<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>,
+			ServerTransport<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>
+		>
+	): void;
+	public addHandlers(service: string, handlers: LooseHandlerMap): void {
+		if (!this._serviceHandlers[service]) {
+			this._serviceHandlers[service] = {};
+		}
+
+		Object.assign(this._serviceHandlers[service], handlers);
 	}
 
 	public addPlugin(...plugin: ServerPlugin<TIncoming, TOutgoing, TChannel, TService, TState, TPrivateIncoming, TPrivateOutgoing, TServerState>[]): void {
@@ -260,6 +324,12 @@ export class Server<
 		return this.brokerEngine.exchange;
 	}
 
+	/** Method names registered under a given service, or an empty array if none. */
+	public getServiceMethods(service: string): string[] {
+		const group = this._serviceHandlers[service];
+		return group ? Object.keys(group) : [];
+	}
+
 	public get isListening(): boolean {
 		return this._isListening;
 	}
@@ -322,6 +392,7 @@ export class Server<
 			plugins: this.plugins,
 			request: upgradeReq,
 			server: this,
+			serviceHandlers: this._serviceHandlers,
 			socket: wsSocket,
 			state: {} as any,
 			streamCleanupMode: this.socketStreamCleanupMode
@@ -354,6 +425,39 @@ export class Server<
 		this._isListening = true;
 
 		this.emit('listening', {});
+	}
+
+	/**
+	 * Unregister either a whole service (when `methods` is omitted) or a
+	 * specific set of methods within a service. Removing a service empties
+	 * the group and drops the key so it no longer appears in {@link services}.
+	 */
+	public removeHandlers(service: string, methods?: readonly string[] | string): void {
+		const group = this._serviceHandlers[service];
+
+		if (!group) {
+			return;
+		}
+
+		if (methods === undefined) {
+			delete this._serviceHandlers[service];
+			return;
+		}
+
+		const list = typeof methods === 'string' ? [methods] : methods;
+
+		for (const method of list) {
+			delete group[method];
+		}
+
+		if (Object.keys(group).length === 0) {
+			delete this._serviceHandlers[service];
+		}
+	}
+
+	/** Names of all service handler groups currently registered on the server. */
+	public get services(): string[] {
+		return Object.keys(this._serviceHandlers);
 	}
 
 	private socketDisconnected(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,31 @@ importers:
         specifier: 'catalog:'
         version: 2.8.1
 
+  packages/cluster-broker:
+    dependencies:
+      '@socket-mesh/async-stream-emitter':
+        specifier: workspace:^
+        version: link:../async-stream-emitter
+      '@socket-mesh/channels':
+        specifier: workspace:^
+        version: link:../channels
+      '@socket-mesh/formatter':
+        specifier: workspace:^
+        version: link:../formatter
+      '@socket-mesh/server':
+        specifier: workspace:^
+        version: link:../server
+      '@socket-mesh/stream-demux':
+        specifier: workspace:^
+        version: link:../stream-demux
+    devDependencies:
+      '@socket-mesh/typescript-config':
+        specifier: workspace:^
+        version: link:../../config/typescript-config
+      '@types/node':
+        specifier: catalog:node
+        version: 25.4.0
+
   packages/consumable-stream:
     devDependencies:
       '@socket-mesh/typescript-config':

--- a/tests/integration/src/server.spec.ts
+++ b/tests/integration/src/server.spec.ts
@@ -3809,4 +3809,82 @@ describe('Server service handlers', function () {
 		const user = await flatClient.invoke(['account', 'find'], 'carol');
 		assert.deepStrictEqual(user, { id: 'carol', name: 'user-carol' });
 	});
+
+	it('Should route invokes to flat handlers added after the server has started', async function () {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+		type FlatMap = {
+			ping: () => string
+		};
+
+		const flatServer: Server<FlatMap, {}, {}, MyServices> =
+			listen<FlatMap, {}, {}, MyServices>(PORT_NUMBER, {});
+
+		serviceServer = flatServer as unknown as Server<{}, {}, {}, MyServices>;
+
+		await flatServer.listen('ready').once(100);
+
+		flatServer.addHandlers({
+			ping: async () => 'pong'
+		});
+
+		const flatClient: ClientSocket<{}, FlatMap, {}, MyServices> =
+			new ClientSocket(clientOptions);
+
+		serviceClient = flatClient as unknown as ClientSocket<{}, {}, {}, MyServices>;
+
+		await flatClient.listen('connect').once(100);
+
+		const pong = await flatClient.invoke('ping');
+		assert.strictEqual(pong, 'pong');
+	});
+
+	it('Should stop routing to a flat handler after removeHandlers removes it by method name', async function () {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+		type FlatMap = {
+			ping: () => string
+		};
+
+		const flatServer: Server<FlatMap, {}, {}, MyServices> =
+			listen<FlatMap, {}, {}, MyServices>(PORT_NUMBER, {
+				ackTimeoutMs: 200,
+				handlers: {
+					ping: async () => 'pong'
+				}
+			});
+
+		serviceServer = flatServer as unknown as Server<{}, {}, {}, MyServices>;
+
+		await flatServer.listen('ready').once(100);
+
+		const flatClient: ClientSocket<{}, FlatMap, {}, MyServices> =
+			new ClientSocket(clientOptions);
+
+		serviceClient = flatClient as unknown as ClientSocket<{}, {}, {}, MyServices>;
+
+		await flatClient.listen('connect').once(100);
+
+		assert.strictEqual(await flatClient.invoke('ping'), 'pong');
+
+		flatServer.removeHandlers(['ping']);
+
+		await assert.rejects(
+			flatClient.invoke({ ackTimeoutMs: 200, method: 'ping' }),
+			(err: Error) => err.name === 'TimeoutError'
+		);
+	});
+
+	it('Should never drop the built-in handlers when removeHandlers is called without a service', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {});
+		await serviceServer.listen('ready').once(100);
+
+		// Calling removeHandlers('') with no method list must be a no-op —
+		// the flat slot holds the built-in protocol handlers (#handshake etc.).
+		serviceServer.removeHandlers('');
+
+		serviceClient = new ClientSocket(clientOptions);
+
+		// If the built-ins were dropped the handshake would never complete and
+		// this `once` would never resolve — the test would hang and then fail.
+		await serviceClient.listen('connect').once(100);
+	});
 });

--- a/tests/integration/src/server.spec.ts
+++ b/tests/integration/src/server.spec.ts
@@ -3482,3 +3482,331 @@ describe('Server Tests', function () {
 		});
 	});
 });
+
+describe('Server service handlers', function () {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+	type AccountMethods = {
+		find: (id: string) => { id: string, name: string },
+		list: () => string[]
+	};
+
+	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+	type InventoryMethods = {
+		getStock: (sku: string) => number
+	};
+
+	// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+	type MyServices = {
+		account: AccountMethods,
+		inventory: InventoryMethods
+	};
+
+	let serviceClient: ClientSocket<{}, {}, {}, MyServices>;
+	let serviceServer: Server<{}, {}, {}, MyServices>;
+
+	afterEach(async function () {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		if (serviceClient) {
+			serviceClient.closeListeners();
+			serviceClient.disconnect();
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		if (serviceServer) {
+			serviceServer.closeListeners();
+			serviceServer.httpServer.close();
+			await serviceServer.close();
+		}
+	});
+
+	it('Should dispatch to handlers provided via options.serviceHandlers', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {
+			ackTimeoutMs: 200,
+			serviceHandlers: {
+				account: {
+					find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+						({ id, name: `user-${id}` }),
+					list: async () => ['alice', 'bob']
+				}
+			}
+		});
+
+		await serviceServer.listen('ready').once(100);
+
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		const user = await serviceClient.invoke(['account', 'find'], 'alice');
+		assert.deepStrictEqual(user, { id: 'alice', name: 'user-alice' });
+
+		const users = await serviceClient.invoke(['account', 'list']);
+		assert.deepStrictEqual(users, ['alice', 'bob']);
+	});
+
+	it('Should merge options.serviceHandlers into the internal map without mutating the input', async function () {
+		const handlersInput = {
+			account: {
+				find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+					({ id, name: `user-${id}` })
+			}
+		};
+
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {
+			serviceHandlers: handlersInput
+		});
+
+		await serviceServer.listen('ready').once(100);
+
+		// Adding a new method on the server must not leak back into the caller's map.
+		serviceServer.addHandlers<'account', AccountMethods>('account', {
+			list: async () => ['alice']
+		});
+
+		assert.deepStrictEqual(Object.keys(handlersInput.account), ['find']);
+		assert.deepStrictEqual(serviceServer.getServiceMethods('account').sort(), ['find', 'list']);
+	});
+
+	it('Should route invokes to handlers added after the server has started', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, { ackTimeoutMs: 200 });
+		await serviceServer.listen('ready').once(100);
+
+		serviceServer.addHandlers<'account', AccountMethods>('account', {
+			find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+				({ id, name: `user-${id}` }),
+			list: async () => ['added-after-start']
+		});
+
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		const user = await serviceClient.invoke(['account', 'find'], 'bob');
+		assert.deepStrictEqual(user, { id: 'bob', name: 'user-bob' });
+
+		const users = await serviceClient.invoke(['account', 'list']);
+		assert.deepStrictEqual(users, ['added-after-start']);
+	});
+
+	it('Should propagate newly added handlers to already-connected clients without reconnect', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, { ackTimeoutMs: 200 });
+		await serviceServer.listen('ready').once(100);
+
+		// Connect the client BEFORE installing the handler group.
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		let calls = 0;
+		serviceServer.addHandlers<'inventory', InventoryMethods>('inventory', {
+			getStock: async ({ options: sku }: ServerRequestHandlerArgs<string>) => {
+				calls++;
+				return sku === 'sku-1' ? 42 : 0;
+			}
+		});
+
+		const stock = await serviceClient.invoke(['inventory', 'getStock'], 'sku-1');
+		assert.strictEqual(stock, 42);
+		assert.strictEqual(calls, 1);
+	});
+
+	it('Should merge handlers when addHandlers is called multiple times on the same service', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, { ackTimeoutMs: 200 });
+		await serviceServer.listen('ready').once(100);
+
+		serviceServer.addHandlers<'account', AccountMethods>('account', {
+			find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+				({ id, name: 'alice' })
+		});
+
+		serviceServer.addHandlers<'account', AccountMethods>('account', {
+			list: async () => ['alice']
+		});
+
+		assert.deepStrictEqual(serviceServer.getServiceMethods('account').sort(), ['find', 'list']);
+
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		const user = await serviceClient.invoke(['account', 'find'], 'a');
+		assert.deepStrictEqual(user, { id: 'a', name: 'alice' });
+
+		const users = await serviceClient.invoke(['account', 'list']);
+		assert.deepStrictEqual(users, ['alice']);
+	});
+
+	it('Should let a later addHandlers call replace an existing method on the same service', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, { ackTimeoutMs: 200 });
+		await serviceServer.listen('ready').once(100);
+
+		serviceServer.addHandlers<'account', AccountMethods>('account', {
+			find: async () => ({ id: 'first', name: 'first' })
+		});
+
+		serviceServer.addHandlers<'account', AccountMethods>('account', {
+			find: async () => ({ id: 'second', name: 'second' })
+		});
+
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		const user = await serviceClient.invoke(['account', 'find'], 'ignored');
+		assert.deepStrictEqual(user, { id: 'second', name: 'second' });
+	});
+
+	it('Should stop routing after removeHandlers drops the whole service group', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {
+			ackTimeoutMs: 200,
+			serviceHandlers: {
+				account: {
+					find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+						({ id, name: `user-${id}` }),
+					list: async () => []
+				}
+			}
+		});
+
+		await serviceServer.listen('ready').once(100);
+
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		const before = await serviceClient.invoke(['account', 'find'], 'alice');
+		assert.deepStrictEqual(before, { id: 'alice', name: 'user-alice' });
+
+		serviceServer.removeHandlers('account');
+		assert.deepStrictEqual(serviceServer.services, []);
+
+		let error: Error | null = null;
+		try {
+			// Tight ack timeout so the test fails fast rather than waiting for the
+			// client's 10s default.
+			await serviceClient.invoke(['account', 'find', 200], 'alice');
+		} catch (err) {
+			error = toError(err);
+		}
+		assert.notEqual(error, null);
+		assert.strictEqual(error!.name, 'TimeoutError');
+	});
+
+	it('Should only drop the specified methods when removeHandlers is called with method names', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {
+			ackTimeoutMs: 200,
+			serviceHandlers: {
+				account: {
+					find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+						({ id, name: `user-${id}` }),
+					list: async () => ['alice', 'bob']
+				}
+			}
+		});
+
+		await serviceServer.listen('ready').once(100);
+
+		serviceClient = new ClientSocket(clientOptions);
+		await serviceClient.listen('connect').once(100);
+
+		serviceServer.removeHandlers('account', 'find');
+		assert.deepStrictEqual(serviceServer.getServiceMethods('account'), ['list']);
+
+		// `list` is still wired up.
+		const users = await serviceClient.invoke(['account', 'list']);
+		assert.deepStrictEqual(users, ['alice', 'bob']);
+
+		// `find` is gone and now times out.
+		let error: Error | null = null;
+		try {
+			await serviceClient.invoke(['account', 'find', 200], 'alice');
+		} catch (err) {
+			error = toError(err);
+		}
+		assert.notEqual(error, null);
+		assert.strictEqual(error!.name, 'TimeoutError');
+	});
+
+	it('Should drop the service key when removeHandlers empties the group', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {
+			serviceHandlers: {
+				account: {
+					find: async () => ({ id: '', name: '' })
+				}
+			}
+		});
+
+		await serviceServer.listen('ready').once(100);
+
+		assert.deepStrictEqual(serviceServer.services, ['account']);
+
+		serviceServer.removeHandlers('account', ['find']);
+		assert.deepStrictEqual(serviceServer.services, []);
+		assert.deepStrictEqual(serviceServer.getServiceMethods('account'), []);
+	});
+
+	it('Should be a no-op when removeHandlers is called for an unknown service', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {});
+		await serviceServer.listen('ready').once(100);
+
+		// Must not throw.
+		serviceServer.removeHandlers('does-not-exist');
+		serviceServer.removeHandlers('does-not-exist', 'find');
+		assert.deepStrictEqual(serviceServer.services, []);
+	});
+
+	it('Should list all registered service names via the `services` getter', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {
+			serviceHandlers: {
+				account: {
+					find: async () => ({ id: '', name: '' })
+				},
+				inventory: {
+					getStock: async () => 0
+				}
+			}
+		});
+
+		await serviceServer.listen('ready').once(100);
+
+		assert.deepStrictEqual(serviceServer.services.sort(), ['account', 'inventory']);
+	});
+
+	it('Should report an empty array from getServiceMethods for an unknown service', async function () {
+		serviceServer = listen<{}, {}, {}, MyServices>(PORT_NUMBER, {});
+		await serviceServer.listen('ready').once(100);
+
+		assert.deepStrictEqual(serviceServer.getServiceMethods('does-not-exist'), []);
+	});
+
+	it('Should keep flat handlers and service handlers isolated from each other', async function () {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+		type FlatMap = {
+			ping: () => string
+		};
+
+		const flatServer: Server<FlatMap, {}, {}, MyServices> = listen<FlatMap, {}, {}, MyServices>(PORT_NUMBER, {
+			ackTimeoutMs: 200,
+			handlers: {
+				ping: async () => 'pong'
+			},
+			serviceHandlers: {
+				account: {
+					find: async ({ options: id }: ServerRequestHandlerArgs<string>) =>
+						({ id, name: `user-${id}` }),
+					list: async () => []
+				}
+			}
+		});
+
+		serviceServer = flatServer as unknown as Server<{}, {}, {}, MyServices>;
+
+		await flatServer.listen('ready').once(100);
+
+		const flatClient: ClientSocket<{}, FlatMap, {}, MyServices> =
+			new ClientSocket(clientOptions);
+
+		serviceClient = flatClient as unknown as ClientSocket<{}, {}, {}, MyServices>;
+
+		await flatClient.listen('connect').once(100);
+
+		const pong = await flatClient.invoke('ping');
+		assert.strictEqual(pong, 'pong');
+
+		const user = await flatClient.invoke(['account', 'find'], 'carol');
+		assert.deepStrictEqual(user, { id: 'carol', name: 'user-carol' });
+	});
+});


### PR DESCRIPTION
## Summary

Two related features for building a multi-process socket-mesh deployment:

### Phase 1 — Service-grouped dynamic request handlers (5214cd4)

- Adds `Server.addHandlers(service, handlers)` / `removeHandlers(service, methods?)` so modules can be loaded after the server is running and still dispatch to new RPC methods on existing connections.
- Handlers are grouped under a `service` key (reusing the `ServiceMap` concept), making it easy to display them in a UI grouped by module.
- Under the hood: `BaseSocketTransport` now holds a shared-reference `_serviceHandlers` map (mutations propagate to every live socket), dispatch checks `packet.service` to route to `_serviceHandlers[service][method]` or the flat `_handlers[method]`.
- `ServerOptions.serviceHandlers?` is strongly typed over `keyof TService & string`.
- `Server.addHandlers` provides two overloads: a strongly-typed one for services known at compile time, and a dynamic `TServiceMethodMap` fallback.
- `Server.services` getter + `Server.getServiceMethods(service)` for UI introspection.
- All 115 integration tests pass.

### Phase 2 — `@socket-mesh/cluster-broker` (c5e131f)

New package that provides a `Broker<T>` implementation for cross-process pub/sub, replacing what socket-cluster did with `SCBroker`.

- **`ClusterBrokerHost`**: master/broker process runs a TCP relay on loopback. Accepts worker connections, tracks subscriptions per channel, fans out publishes to all subscribed workers **except the origin** (since the origin already delivered locally).
- **`ClusterBroker<T extends ChannelMap>`**: worker-side `Broker<T>` that can be plugged directly into `Server.brokerEngine`. Mirrors `SimpleBroker`'s local subscriber table, plus:
  - Sends a `subscribe` frame on first local subscriber, `unsubscribe` frame on last local unsubscriber.
  - On local publish: delivers locally + relays a `publish` frame over TCP.
  - On incoming `publish` frame: delivers to local subscribers only (origin already handled).
  - Reconnects on TCP loss with exponential backoff (200ms base, 30s cap) and re-sends every tracked subscription on reconnect.
- **Wire format**: 4-byte big-endian length prefix + JSON payload encoded via a pluggable `CodecEngine` (defaults to `JSON.stringify`).
- 5 integration tests cover: local-only delivery, cross-worker fanout, no self-echo guarantee, unsubscribe clears forwarding, and host worker-count tracking. All pass.

### Phase 3 — tsconfig + test typing (e78fc03)

- Registers `@socket-mesh/cluster-broker` in the shared `config/typescript-config/tsconfig.build.json` path map so downstream packages can resolve its `.d.ts` during build.
- Fixes the test `Channels` interface to extend `ChannelMap` so it satisfies the `Broker<T extends ChannelMap>` generic constraint.

## Test plan

- [x] Phase 1: `pnpm --filter ./tests/integration test` — 115/115 pass
- [x] Phase 1: `pnpm --filter @socket-mesh/{core,client,server} lint` clean
- [x] Phase 2: `pnpm --filter @socket-mesh/cluster-broker build` clean
- [x] Phase 2: `pnpm --filter @socket-mesh/cluster-broker lint` clean
- [x] Phase 2: `pnpm --filter @socket-mesh/cluster-broker test` — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)